### PR TITLE
feat: 프론트엔드 컴포넌트 및 테스트 추가

### DIFF
--- a/apps/web/src/api/health.test.ts
+++ b/apps/web/src/api/health.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { checkHealth } from './health';
+
+describe('checkHealth', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  // 성공 케이스: HealthResponse를 반환해야 함
+  it('성공 시 HealthResponse를 반환해야 함', async () => {
+    const mockData = {
+      status: 'ok',
+      timestamp: '2026-01-13T10:00:00Z',
+      uptime: 3600,
+    };
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => mockData,
+    });
+
+    const result = await checkHealth();
+
+    expect(result).toEqual(mockData);
+    expect(result.status).toBe('ok');
+    expect(result.timestamp).toBe('2026-01-13T10:00:00Z');
+    expect(result.uptime).toBe(3600);
+  });
+
+  // 에러 케이스: fetch 실패 시 에러를 던져야 함
+  it('fetch 실패 시 에러를 던져야 함', async () => {
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: false,
+    });
+
+    await expect(checkHealth()).rejects.toThrow('Health check failed');
+  });
+
+  // 네트워크 에러 처리
+  it('네트워크 에러 발생 시 예외를 던져야 함', async () => {
+    (global.fetch as vi.Mock).mockRejectedValue(new Error('Network error'));
+
+    await expect(checkHealth()).rejects.toThrow('Network error');
+  });
+
+  // 응답 파싱 검증
+  it('응답 JSON을 올바르게 파싱해야 함', async () => {
+    const mockData = {
+      status: 'healthy',
+      timestamp: '2026-01-13T12:30:45Z',
+      uptime: 86400,
+    };
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => mockData,
+    });
+
+    const result = await checkHealth();
+
+    expect(result).toEqual(mockData);
+    expect(global.fetch).toHaveBeenCalledWith('/api/health');
+  });
+
+  // 엔드포인트 URL 검증
+  it('올바른 엔드포인트를 호출해야 함', async () => {
+    const mockData = { status: 'ok', timestamp: '2026-01-13T10:00:00Z', uptime: 100 };
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => mockData,
+    });
+
+    await checkHealth();
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/health');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/api/meeting.test.ts
+++ b/apps/web/src/api/meeting.test.ts
@@ -1,0 +1,419 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  fetchDashboard,
+  createMeeting,
+  submitResponse,
+  sendReminder,
+  confirmMeeting,
+} from './meeting';
+
+describe('fetchDashboard', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  // 성공 케이스: 대시보드 데이터를 반환해야 함
+  it('성공 시 대시보드 데이터를 반환해야 함', async () => {
+    const mockData = {
+      requestId: 'req-123',
+      title: '회의 제목',
+      status: 'pending',
+      participants: [],
+      commonAvailableSlots: [],
+      createdAt: '2026-01-13T10:00:00Z',
+      startDate: '2026-01-15',
+      endDate: '2026-01-17',
+      durationMinutes: 60,
+    };
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => mockData,
+    });
+
+    const result = await fetchDashboard('req-123');
+
+    expect(result).toEqual(mockData);
+  });
+
+  // GET 메서드 검증
+  it('GET 메서드로 요청해야 함', async () => {
+    const mockData = { requestId: 'req-123', title: 'Test' };
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => mockData,
+    });
+
+    await fetchDashboard('req-123');
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/meetings/req-123/dashboard');
+  });
+
+  // 에러 케이스: fetch 실패 시 에러를 던져야 함
+  it('fetch 실패 시 에러를 던져야 함', async () => {
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: false,
+    });
+
+    await expect(fetchDashboard('req-123')).rejects.toThrow('Failed to fetch dashboard');
+  });
+});
+
+describe('createMeeting', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  // 성공 케이스: 회의 생성 응답을 반환해야 함
+  it('성공 시 회의 생성 응답을 반환해야 함', async () => {
+    const payload = {
+      title: '면접 회의',
+      description: '1차 면접',
+      durationMinutes: 60,
+      startDate: '2026-01-15',
+      endDate: '2026-01-17',
+      participantIds: ['user-1', 'user-2'],
+      organizerId: 'org-1',
+    };
+    const mockResponse = {
+      requestId: 'req-new',
+      meetingUrl: 'https://example.com/meetings/req-new',
+      responseUrl: 'https://example.com/meetings/req-new/respond',
+    };
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    const result = await createMeeting(payload);
+
+    expect(result).toEqual(mockResponse);
+  });
+
+  // POST 메서드 검증
+  it('POST 메서드로 요청해야 함', async () => {
+    const payload = {
+      title: 'Test',
+      durationMinutes: 60,
+      startDate: '2026-01-15',
+      endDate: '2026-01-17',
+      participantIds: ['user-1'],
+      organizerId: 'org-1',
+    };
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ requestId: 'req-1' }),
+    });
+
+    await createMeeting(payload);
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/meetings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  });
+
+  // 페이로드 검증: 올바른 body 전송
+  it('올바른 페이로드를 전송해야 함', async () => {
+    const payload = {
+      title: '제목',
+      description: '설명',
+      durationMinutes: 90,
+      startDate: '2026-01-20',
+      endDate: '2026-01-22',
+      participantIds: ['p1', 'p2', 'p3'],
+      organizerId: 'org-1',
+    };
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ requestId: 'req-2' }),
+    });
+
+    await createMeeting(payload);
+
+    const callArgs = (global.fetch as vi.Mock).mock.calls[0];
+    const body = JSON.parse(callArgs[1].body);
+    expect(body).toEqual(payload);
+  });
+
+  // 엔드포인트 URL 검증
+  it('올바른 엔드포인트를 호출해야 함', async () => {
+    const payload = {
+      title: 'Test',
+      durationMinutes: 60,
+      startDate: '2026-01-15',
+      endDate: '2026-01-17',
+      participantIds: ['user-1'],
+      organizerId: 'org-1',
+    };
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ requestId: 'req-1' }),
+    });
+
+    await createMeeting(payload);
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/meetings', expect.any(Object));
+  });
+
+  // 에러 케이스: fetch 실패 시 에러를 던져야 함
+  it('fetch 실패 시 에러를 던져야 함', async () => {
+    const payload = {
+      title: 'Test',
+      durationMinutes: 60,
+      startDate: '2026-01-15',
+      endDate: '2026-01-17',
+      participantIds: ['user-1'],
+      organizerId: 'org-1',
+    };
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: false,
+    });
+
+    await expect(createMeeting(payload)).rejects.toThrow('Failed to create meeting');
+  });
+});
+
+describe('submitResponse', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  // 성공 케이스: 응답 제출 성공
+  it('성공 시 응답 제출 결과를 반환해야 함', async () => {
+    const payload = {
+      requestId: 'req-123',
+      userId: 'user-1',
+      name: '홍길동',
+      availableSlots: ['2026-01-15T09:00', '2026-01-15T10:00'],
+      unavailableSlots: ['2026-01-15T11:00'],
+    };
+    const mockResponse = { success: true };
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    const result = await submitResponse(payload);
+
+    expect(result).toEqual(mockResponse);
+  });
+
+  // POST 메서드 검증
+  it('POST 메서드로 요청해야 함', async () => {
+    const payload = {
+      requestId: 'req-123',
+      userId: 'user-1',
+      name: '홍길동',
+      availableSlots: [],
+      unavailableSlots: [],
+    };
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+
+    await submitResponse(payload);
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/meetings/req-123/respond', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  });
+
+  // 페이로드 검증
+  it('올바른 페이로드를 전송해야 함', async () => {
+    const payload = {
+      requestId: 'req-456',
+      userId: 'user-2',
+      name: '김철수',
+      availableSlots: ['slot1', 'slot2'],
+      unavailableSlots: ['slot3'],
+    };
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+
+    await submitResponse(payload);
+
+    const callArgs = (global.fetch as vi.Mock).mock.calls[0];
+    const body = JSON.parse(callArgs[1].body);
+    expect(body).toEqual(payload);
+  });
+
+  // 에러 케이스: fetch 실패 시 에러를 던져야 함
+  it('fetch 실패 시 에러를 던져야 함', async () => {
+    const payload = {
+      requestId: 'req-123',
+      userId: 'user-1',
+      name: '홍길동',
+      availableSlots: [],
+      unavailableSlots: [],
+    };
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: false,
+    });
+
+    await expect(submitResponse(payload)).rejects.toThrow('Failed to submit response');
+  });
+});
+
+describe('sendReminder', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  // 성공 케이스: 리마인더 전송 성공
+  it('성공 시 리마인더 전송 결과를 반환해야 함', async () => {
+    const mockResponse = { sent: true };
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    const result = await sendReminder('req-123', 'user-1');
+
+    expect(result).toEqual(mockResponse);
+  });
+
+  // POST 메서드 검증
+  it('POST 메서드로 요청해야 함', async () => {
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ sent: true }),
+    });
+
+    await sendReminder('req-123', 'user-1');
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/meetings/req-123/remind/user-1', {
+      method: 'POST',
+    });
+  });
+
+  // 엔드포인트 URL 검증
+  it('올바른 엔드포인트를 호출해야 함', async () => {
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ sent: true }),
+    });
+
+    await sendReminder('req-456', 'user-2');
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/meetings/req-456/remind/user-2', {
+      method: 'POST',
+    });
+  });
+
+  // 에러 케이스: fetch 실패 시 에러를 던져야 함
+  it('fetch 실패 시 에러를 던져야 함', async () => {
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: false,
+    });
+
+    await expect(sendReminder('req-123', 'user-1')).rejects.toThrow(
+      'Failed to send reminder',
+    );
+  });
+});
+
+describe('confirmMeeting', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  // 성공 케이스: 회의 확정 성공
+  it('성공 시 회의 확정 결과를 반환해야 함', async () => {
+    const payload = {
+      requestId: 'req-123',
+      confirmedStart: '2026-01-16T10:00:00',
+      confirmedEnd: '2026-01-16T11:00:00',
+      roomId: 'room-1',
+    };
+    const mockResponse = { confirmed: true, meetingId: 'm-123' };
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    const result = await confirmMeeting(payload);
+
+    expect(result).toEqual(mockResponse);
+  });
+
+  // POST 메서드 검증
+  it('POST 메서드로 요청해야 함', async () => {
+    const payload = {
+      requestId: 'req-123',
+      confirmedStart: '2026-01-16T10:00:00',
+      confirmedEnd: '2026-01-16T11:00:00',
+      roomId: 'room-1',
+    };
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ confirmed: true }),
+    });
+
+    await confirmMeeting(payload);
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/meetings/confirm', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  });
+
+  // 페이로드 검증
+  it('올바른 페이로드를 전송해야 함', async () => {
+    const payload = {
+      requestId: 'req-456',
+      confirmedStart: '2026-01-17T14:00:00',
+      confirmedEnd: '2026-01-17T15:00:00',
+      roomId: 'room-2',
+    };
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ confirmed: true }),
+    });
+
+    await confirmMeeting(payload);
+
+    const callArgs = (global.fetch as vi.Mock).mock.calls[0];
+    const body = JSON.parse(callArgs[1].body);
+    expect(body).toEqual(payload);
+  });
+
+  // 엔드포인트 URL 검증
+  it('올바른 엔드포인트를 호출해야 함', async () => {
+    const payload = {
+      requestId: 'req-123',
+      confirmedStart: '2026-01-16T10:00:00',
+      confirmedEnd: '2026-01-16T11:00:00',
+      roomId: 'room-1',
+    };
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ confirmed: true }),
+    });
+
+    await confirmMeeting(payload);
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/meetings/confirm', expect.any(Object));
+  });
+
+  // 에러 케이스: fetch 실패 시 에러를 던져야 함
+  it('fetch 실패 시 에러를 던져야 함', async () => {
+    const payload = {
+      requestId: 'req-123',
+      confirmedStart: '2026-01-16T10:00:00',
+      confirmedEnd: '2026-01-16T11:00:00',
+      roomId: 'room-1',
+    };
+    (global.fetch as vi.Mock).mockResolvedValue({
+      ok: false,
+    });
+
+    await expect(confirmMeeting(payload)).rejects.toThrow('Failed to confirm meeting');
+  });
+});

--- a/apps/web/src/components/common-slots.test.tsx
+++ b/apps/web/src/components/common-slots.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CommonSlots from './common-slots';
+
+describe('CommonSlots', () => {
+  const mockSlots = [
+    {
+      date: '2026-01-15',
+      times: ['09:00', '10:00', '11:00'],
+    },
+    {
+      date: '2026-01-16',
+      times: ['14:00', '15:00'],
+    },
+  ];
+
+  it('날짜별 슬롯이 올바르게 표시되어야 함', () => {
+    const onSelectSlot = vi.fn();
+    render(<CommonSlots slots={mockSlots} onSelectSlot={onSelectSlot} />);
+
+    expect(screen.getByText('모두 가능한 시간')).toBeInTheDocument();
+    expect(screen.getByText('2026년 1월 15일 목요일')).toBeInTheDocument();
+    expect(screen.getByText('2026년 1월 16일 금요일')).toBeInTheDocument();
+    expect(screen.getByText('09:00')).toBeInTheDocument();
+    expect(screen.getByText('10:00')).toBeInTheDocument();
+    expect(screen.getByText('14:00')).toBeInTheDocument();
+    expect(screen.getByText('15:00')).toBeInTheDocument();
+  });
+
+  it('날짜가 한국어 형식으로 올바르게 표시되어야 함', () => {
+    const onSelectSlot = vi.fn();
+    render(<CommonSlots slots={mockSlots} onSelectSlot={onSelectSlot} />);
+
+    expect(screen.getByText('2026년 1월 15일 목요일')).toBeInTheDocument();
+    expect(screen.getByText('2026년 1월 16일 금요일')).toBeInTheDocument();
+  });
+
+  it('슬롯 선택 시 선택 상태가 표시되어야 함', async () => {
+    const user = userEvent.setup();
+    const onSelectSlot = vi.fn();
+    render(<CommonSlots slots={mockSlots} onSelectSlot={onSelectSlot} />);
+
+    const slot = screen.getByText('09:00');
+    await user.click(slot);
+
+    expect(screen.getByText('선택됨')).toBeInTheDocument();
+    expect(onSelectSlot).toHaveBeenCalledWith('2026-01-15', '09:00');
+  });
+
+  it('다른 슬롯 클릭 시 선택 상태가 변경되어야 함', async () => {
+    const user = userEvent.setup();
+    const onSelectSlot = vi.fn();
+    render(<CommonSlots slots={mockSlots} onSelectSlot={onSelectSlot} />);
+
+    const firstSlot = screen.getByText('09:00');
+    await user.click(firstSlot);
+
+    expect(screen.getByText('선택됨')).toBeInTheDocument();
+
+    const secondSlot = screen.getByText('10:00');
+    await user.click(secondSlot);
+
+    expect(screen.getAllByText('선택됨')).toHaveLength(1);
+    expect(onSelectSlot).toHaveBeenLastCalledWith('2026-01-15', '10:00');
+  });
+
+  it('슬롯이 없을 경우 빈 상태 메시지가 표시되어야 함', () => {
+    const onSelectSlot = vi.fn();
+    render(<CommonSlots slots={[]} onSelectSlot={onSelectSlot} />);
+
+    expect(screen.getByText('공통 가능한 시간이 없습니다.')).toBeInTheDocument();
+    expect(screen.queryByText('09:00')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/confirm-dialog.test.tsx
+++ b/apps/web/src/components/confirm-dialog.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ConfirmDialog from './confirm-dialog';
+
+describe('ConfirmDialog', () => {
+  const defaultProps = {
+    open: true,
+    title: '삭제 확인',
+    message: '정말 삭제하시겠습니까?',
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  it('open이 true일 때 다이얼로그가 표시되어야 함', () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    
+    expect(screen.getByText('삭제 확인')).toBeInTheDocument();
+    expect(screen.getByText('정말 삭제하시겠습니까?')).toBeInTheDocument();
+  });
+
+  it('open이 false일 때 다이얼로그가 표시되지 않아야 함', () => {
+    render(<ConfirmDialog {...defaultProps} open={false} />);
+    
+    expect(screen.queryByText('삭제 확인')).not.toBeInTheDocument();
+  });
+
+  it('title이 올바르게 렌더링되어야 함', () => {
+    render(<ConfirmDialog {...defaultProps} title="제목 변경" />);
+    
+    expect(screen.getByText('제목 변경')).toBeInTheDocument();
+  });
+
+  it('message가 올바르게 렌더링되어야 함', () => {
+    render(<ConfirmDialog {...defaultProps} message="메시지 변경" />);
+    
+    expect(screen.getByText('메시지 변경')).toBeInTheDocument();
+  });
+
+  it('확인 버튼 클릭 시 onConfirm 핸들러가 호출되어야 함', async () => {
+    const user = userEvent.setup();
+    render(<ConfirmDialog {...defaultProps} />);
+    
+    const confirmButton = screen.getByRole('button', { name: '확인' });
+    await user.click(confirmButton);
+    
+    expect(defaultProps.onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('취소 버튼 클릭 시 onCancel 핸들러가 호출되어야 함', async () => {
+    const user = userEvent.setup();
+    render(<ConfirmDialog {...defaultProps} />);
+    
+    const cancelButton = screen.getByRole('button', { name: '취소' });
+    await user.click(cancelButton);
+    
+    expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('onConfirm과 onCancel이 각각 한 번씩 호출되어야 함', async () => {
+    const user = userEvent.setup();
+    render(<ConfirmDialog {...defaultProps} />);
+    
+    const cancelButton = screen.getByRole('button', { name: '취소' });
+    const confirmButton = screen.getByRole('button', { name: '확인' });
+    
+    await user.click(cancelButton);
+    await user.click(confirmButton);
+    
+    expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/empty-state.test.tsx
+++ b/apps/web/src/components/empty-state.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import EmptyState from './empty-state';
+
+describe('EmptyState', () => {
+  // 아이콘 렌더링 테스트
+  it('SentimentDissatisfied 아이콘을 렌더링해야 함', () => {
+    render(<EmptyState message="데이터가 없습니다" />);
+
+    const icon = document.querySelector('svg');
+    expect(icon).toBeInTheDocument();
+  });
+
+  // 메시지 렌더링 테스트
+  it('메시지를 렌더링해야 함', () => {
+    render(<EmptyState message="등록된 일정이 없습니다" />);
+
+    const message = screen.getByText('등록된 일정이 없습니다');
+    expect(message).toBeInTheDocument();
+  });
+
+  it('메시지를 h6 요소로 렌더링해야 함', () => {
+    render(<EmptyState message="데이터 없음" />);
+
+    const message = screen.getByRole('heading', { level: 6, name: '데이터 없음' });
+    expect(message).toBeInTheDocument();
+  });
+
+  // 액션 버튼 렌더링 테스트
+  it('액션 버튼을 렌더링해야 함', () => {
+    const action = <button type="button">새로 만들기</button>;
+    render(<EmptyState message="데이터 없음" action={action} />);
+
+    const button = screen.getByRole('button', { name: '새로 만들기' });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('액션이 제공되지 않으면 렌더링하지 않아야 함', () => {
+    render(<EmptyState message="데이터 없음" />);
+
+    const button = screen.queryByRole('button');
+    expect(button).not.toBeInTheDocument();
+  });
+
+  // Container 및 레이아웃 구조 테스트
+  it('Container 컴포넌트로 감싸져 있어야 함', () => {
+    render(<EmptyState message="데이터 없음" />);
+
+    const message = screen.getByText('데이터 없음');
+    const container = message.closest('.MuiContainer-root');
+
+    expect(container).toBeInTheDocument();
+  });
+
+  it('중앙 정렬 레이아웃을 가지고 있어야 함', () => {
+    const { container } = render(<EmptyState message="데이터 없음" />);
+
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveClass('MuiContainer-root');
+  });
+
+  // 통합 테스트
+  it('모든 요소를 함께 렌더링해야 함', () => {
+    const action = <button type="button">일정 추가</button>;
+    render(
+      <EmptyState
+        message="아직 회의 일정이 없습니다"
+        action={action}
+      />,
+    );
+
+    const icon = document.querySelector('svg');
+    const message = screen.getByText('아직 회의 일정이 없습니다');
+    const button = screen.getByRole('button', { name: '일정 추가' });
+
+    expect(icon).toBeInTheDocument();
+    expect(message).toBeInTheDocument();
+    expect(button).toBeInTheDocument();
+  });
+
+  // 다양한 메시지 시나리오 테스트
+  it('긴 메시지도 올바르게 렌더링해야 함', () => {
+    const longMessage = '현재 표시할 데이터가 없습니다. 새로운 일정을 생성해주세요.';
+    render(<EmptyState message={longMessage} />);
+
+    const message = screen.getByText(longMessage);
+    expect(message).toBeInTheDocument();
+  });
+
+  it('다양한 액션 요소를 렌더링할 수 있어야 함', () => {
+    const action = (
+      <div>
+        <button type="button">버튼 1</button>
+        <button type="button">버튼 2</button>
+      </div>
+    );
+    render(<EmptyState message="데이터 없음" action={action} />);
+
+    const button1 = screen.getByRole('button', { name: '버튼 1' });
+    const button2 = screen.getByRole('button', { name: '버튼 2' });
+
+    expect(button1).toBeInTheDocument();
+    expect(button2).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/floating-button.test.tsx
+++ b/apps/web/src/components/floating-button.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FloatingButton from './floating-button';
+
+describe('FloatingButton', () => {
+  it('Fab 컴포넌트가 렌더링되어야 함', () => {
+    render(<FloatingButton onClick={vi.fn()} />);
+    
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+  });
+
+  it('고정된 위치를 가져야 함 (bottom: 16, right: 16)', () => {
+    render(<FloatingButton onClick={vi.fn()} />);
+    
+    const button = screen.getByRole('button');
+    expect(button).toHaveStyle({
+      position: 'fixed',
+      bottom: '16px',
+      right: '16px',
+    });
+  });
+
+  it('클릭 시 onClick 핸들러가 호출되어야 함', async () => {
+    const handleClick = vi.fn();
+    const user = userEvent.setup();
+    
+    render(<FloatingButton onClick={handleClick} />);
+    
+    const button = screen.getByRole('button');
+    await user.click(button);
+    
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('기본 aria-label이 설정되어야 함', () => {
+    render(<FloatingButton onClick={vi.fn()} />);
+    
+    const button = screen.getByRole('button', { name: '새 일정 만들기' });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('커스텀 label이 제공되면 해당 값이 aria-label로 설정되어야 함', () => {
+    render(<FloatingButton onClick={vi.fn()} label="새 항목 추가" />);
+    
+    const button = screen.getByRole('button', { name: '새 항목 추가' });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('AddIcon이 렌더링되어야 함', () => {
+    render(<FloatingButton onClick={vi.fn()} />);
+    
+    const icon = document.querySelector('svg');
+    expect(icon).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/loading-state.test.tsx
+++ b/apps/web/src/components/loading-state.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import LoadingState from './loading-state';
+
+describe('LoadingState', () => {
+  // CircularProgress 렌더링 테스트
+  it('CircularProgress를 렌더링해야 함', () => {
+    render(<LoadingState />);
+
+    const progress = screen.getByRole('progressbar');
+    expect(progress).toBeInTheDocument();
+  });
+
+  // 기본 메시지 테스트
+  it('기본 메시지 "로딩 중..."을 렌더링해야 함', () => {
+    render(<LoadingState />);
+
+    const message = screen.getByText('로딩 중...');
+    expect(message).toBeInTheDocument();
+  });
+
+  // 커스텀 메시지 테스트
+  it('커스텀 메시지를 렌더링해야 함', () => {
+    render(<LoadingState message="데이터를 불러오는 중..." />);
+
+    const message = screen.getByText('데이터를 불러오는 중...');
+    expect(message).toBeInTheDocument();
+  });
+
+  it('커스텀 메시지가 제공되면 기본 메시지를 덮어써야 함', () => {
+    render(<LoadingState message="저장 중..." />);
+
+    const defaultMessage = screen.queryByText('로딩 중...');
+    const customMessage = screen.getByText('저장 중...');
+
+    expect(defaultMessage).not.toBeInTheDocument();
+    expect(customMessage).toBeInTheDocument();
+  });
+
+  // 레이아웃 구조 테스트
+  it('메시지와 CircularProgress가 함께 렌더링되어야 함', () => {
+    render(<LoadingState message="처리 중..." />);
+
+    const progress = screen.getByRole('progressbar');
+    const message = screen.getByText('처리 중...');
+
+    expect(progress).toBeInTheDocument();
+    expect(message).toBeInTheDocument();
+  });
+
+  it('중앙 정렬 레이아웃을 가지고 있어야 함', () => {
+    const { container } = render(<LoadingState />);
+
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveStyle({
+      minHeight: '50vh',
+    });
+  });
+
+  // 다양한 메시지 시나리오 테스트
+  it('긴 메시지도 올바르게 렌더링해야 함', () => {
+    const longMessage = '서버에서 데이터를 가져오는 중입니다. 잠시만 기다려 주세요.';
+    render(<LoadingState message={longMessage} />);
+
+    const message = screen.getByText(longMessage);
+    expect(message).toBeInTheDocument();
+  });
+
+  it('비어 있는 메시지를 처리해야 함', () => {
+    render(<LoadingState message="" />);
+
+    const progress = screen.getByRole('progressbar');
+    expect(progress).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/meeting-card.test.tsx
+++ b/apps/web/src/components/meeting-card.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MeetingCard from './meeting-card';
+
+describe('MeetingCard', () => {
+  const defaultProps = {
+    title: '면접 일정',
+    date: '2026-01-15 ~ 2026-01-17',
+    responseRate: 66,
+    totalParticipants: 3,
+    respondedParticipants: 2,
+    onClick: vi.fn(),
+  };
+
+  it('모든 props가 올바르게 렌더링되어야 함', () => {
+    render(<MeetingCard {...defaultProps} />);
+
+    expect(screen.getByText('면접 일정')).toBeInTheDocument();
+    expect(screen.getByText('2026-01-15 ~ 2026-01-17')).toBeInTheDocument();
+    expect(screen.getByText('응답률')).toBeInTheDocument();
+    expect(screen.getByText('66%')).toBeInTheDocument();
+    expect(screen.getByText('참석자:')).toBeInTheDocument();
+    expect(screen.getByText('2/3')).toBeInTheDocument();
+    expect(screen.getByText('상세 보기')).toBeInTheDocument();
+  });
+
+  it('ProgressBar의 응답률이 올바르게 표시되어야 함', () => {
+    render(<MeetingCard {...defaultProps} />);
+
+    expect(screen.getByText('응답률')).toBeInTheDocument();
+    expect(screen.getByText('66%')).toBeInTheDocument();
+  });
+
+  it('응답률에 따른 참석자 비율이 올바르게 계산되어 표시되어야 함', () => {
+    const props = {
+      ...defaultProps,
+      responseRate: 100,
+      totalParticipants: 5,
+      respondedParticipants: 5,
+    };
+
+    render(<MeetingCard {...props} />);
+
+    expect(screen.getByText('100%')).toBeInTheDocument();
+    expect(screen.getByText('5/5')).toBeInTheDocument();
+  });
+
+  it('카드 클릭 시 onClick 핸들러가 호출되어야 함', async () => {
+    const user = userEvent.setup();
+    render(<MeetingCard {...defaultProps} />);
+
+    const card = screen.getByText('면접 일정').closest('[role="button"]') || screen.getByText('면접 일정').closest('.MuiCard-root');
+    await user.click(card!);
+
+    expect(defaultProps.onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('날짜 범위가 올바르게 표시되어야 함', () => {
+    const props = {
+      ...defaultProps,
+      date: '2026-02-01 ~ 2026-02-05',
+    };
+
+    render(<MeetingCard {...props} />);
+
+    expect(screen.getByText('2026-02-01 ~ 2026-02-05')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/participant-list.test.tsx
+++ b/apps/web/src/components/participant-list.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ParticipantList from './participant-list';
+
+describe('ParticipantList', () => {
+  const mockParticipants = [
+    {
+      id: 'user-1',
+      name: '김철수',
+      department: '개발팀',
+      status: 'responded' as const,
+    },
+    {
+      id: 'user-2',
+      name: '이영희',
+      department: '디자인팀',
+      status: 'pending' as const,
+    },
+    {
+      id: 'user-3',
+      name: '박민수',
+      department: '마케팅팀',
+      status: 'pending' as const,
+    },
+  ];
+
+  it('모든 참석자를 올바르게 렌더링해야 함', () => {
+    render(
+      <ParticipantList
+        participants={mockParticipants}
+        onRemind={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('김철수')).toBeInTheDocument();
+    expect(screen.getByText('이영희')).toBeInTheDocument();
+    expect(screen.getByText('박민수')).toBeInTheDocument();
+    expect(screen.getByText('개발팀')).toBeInTheDocument();
+    expect(screen.getByText('디자인팀')).toBeInTheDocument();
+    expect(screen.getByText('마케팅팀')).toBeInTheDocument();
+  });
+
+  it('응답한 참석자에게 체크 아이콘을 표시해야 함', () => {
+    render(
+      <ParticipantList
+        participants={mockParticipants}
+        onRemind={vi.fn()}
+      />,
+    );
+
+    const checkIcon = screen.getByText('김철수').closest('div')?.querySelector('svg');
+    expect(checkIcon).toBeInTheDocument();
+  });
+
+  it('대기 중인 참석자에게 시계 아이콘을 표시해야 함', () => {
+    render(
+      <ParticipantList
+        participants={mockParticipants}
+        onRemind={vi.fn()}
+      />,
+    );
+
+    const pendingText = screen.getByText('이영희').parentElement?.parentElement;
+    expect(pendingText).toContainElement(screen.getByText('디자인팀'));
+  });
+
+  it('대기 중인 참석자에게만 재요청 버튼을 표시해야 함', () => {
+    render(
+      <ParticipantList
+        participants={mockParticipants}
+        onRemind={vi.fn()}
+      />,
+    );
+
+    const remindButtons = screen.getAllByText('재요청');
+    expect(remindButtons).toHaveLength(2);
+  });
+
+  it('재요청 버튼 클릭 시 onRemind를 올바른 userId로 호출해야 함', async () => {
+    const user = userEvent.setup();
+    const handleRemind = vi.fn();
+
+    render(
+      <ParticipantList
+        participants={mockParticipants}
+        onRemind={handleRemind}
+      />,
+    );
+
+    const remindButtons = screen.getAllByText('재요청');
+    await user.click(remindButtons[0]);
+
+    expect(handleRemind).toHaveBeenCalledWith('user-2');
+  });
+});

--- a/apps/web/src/components/progress-bar.test.tsx
+++ b/apps/web/src/components/progress-bar.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ProgressBar from './progress-bar';
+
+describe('ProgressBar', () => {
+  // 값 렌더링 테스트
+  it('0% 값을 올바르게 렌더링해야 함', () => {
+    render(<ProgressBar value={0} />);
+
+    const progress = screen.getByRole('progressbar');
+    expect(progress).toBeInTheDocument();
+    expect(progress).toHaveAttribute('aria-valuenow', '0');
+  });
+
+  it('50% 값을 올바르게 렌더링해야 함', () => {
+    render(<ProgressBar value={50} />);
+
+    const progress = screen.getByRole('progressbar');
+    expect(progress).toHaveAttribute('aria-valuenow', '50');
+  });
+
+  it('100% 값을 올바르게 렌더링해야 함', () => {
+    render(<ProgressBar value={100} />);
+
+    const progress = screen.getByRole('progressbar');
+    expect(progress).toHaveAttribute('aria-valuenow', '100');
+  });
+
+  // 라벨 렌더링 테스트
+  it('라벨을 렌더링해야 함', () => {
+    render(<ProgressBar value={75} label="진행률" />);
+
+    const label = screen.getByText('진행률');
+    expect(label).toBeInTheDocument();
+  });
+
+  it('라벨과 함께 퍼센트 표시를 렌더링해야 함', () => {
+    render(<ProgressBar value={60} label="완료율" />);
+
+    const percentage = screen.getByText('60%');
+    expect(percentage).toBeInTheDocument();
+  });
+
+  it('라벨이 제공되지 않으면 렌더링하지 않아야 함', () => {
+    render(<ProgressBar value={50} />);
+
+    const label = screen.queryByText(/%/);
+    expect(label).not.toBeInTheDocument();
+  });
+
+  // 색상 변형 테스트
+  it('primary 색상을 올바르게 렌더링해야 함', () => {
+    render(<ProgressBar value={50} color="primary" />);
+
+    const progress = screen.getByRole('progressbar');
+    expect(progress).toBeInTheDocument();
+  });
+
+  it('success 색상을 올바르게 렌더링해야 함', () => {
+    render(<ProgressBar value={100} color="success" />);
+
+    const progress = screen.getByRole('progressbar');
+    expect(progress).toBeInTheDocument();
+  });
+
+  it('warning 색상을 올바르게 렌더링해야 함', () => {
+    render(<ProgressBar value={50} color="warning" />);
+
+    const progress = screen.getByRole('progressbar');
+    expect(progress).toBeInTheDocument();
+  });
+
+  it('error 색상을 올바르게 렌더링해야 함', () => {
+    render(<ProgressBar value={25} color="error" />);
+
+    const progress = screen.getByRole('progressbar');
+    expect(progress).toBeInTheDocument();
+  });
+
+  // 기본 색상 테스트
+  it('색상이 제공되지 않으면 primary가 기본값이어야 함', () => {
+    render(<ProgressBar value={50} />);
+
+    const progress = screen.getByRole('progressbar');
+    expect(progress).toBeInTheDocument();
+  });
+
+  // 전체 구조 테스트
+  it('모든 요소를 함께 렌더링해야 함', () => {
+    render(<ProgressBar value={80} label="완료율" color="success" />);
+
+    const label = screen.getByText('완료율');
+    const percentage = screen.getByText('80%');
+    const progress = screen.getByRole('progressbar');
+
+    expect(label).toBeInTheDocument();
+    expect(percentage).toBeInTheDocument();
+    expect(progress).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/room-selector.test.tsx
+++ b/apps/web/src/components/room-selector.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RoomSelector from './room-selector';
+
+describe('RoomSelector', () => {
+  const mockRooms = [
+    { id: 'room-1', name: '회의실 A', capacity: 10 },
+    { id: 'room-2', name: '회의실 B', capacity: 20 },
+    { id: 'room-3', name: '회의실 C', capacity: 8 },
+  ];
+
+  it('모든 회의실 옵션을 올바르게 렌더링해야 함', () => {
+    render(
+      <RoomSelector
+        rooms={mockRooms}
+        selectedRoomId={null}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('회의실 A (최대 10인)')).toBeInTheDocument();
+    expect(screen.getByText('회의실 B (최대 20인)')).toBeInTheDocument();
+    expect(screen.getByText('회의실 C (최대 8인)')).toBeInTheDocument();
+  });
+
+  it('회의실 선택 시 onChange를 올바른 roomId로 호출해야 함', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    render(
+      <RoomSelector
+        rooms={mockRooms}
+        selectedRoomId={null}
+        onChange={handleChange}
+      />,
+    );
+
+    const select = screen.getByRole('combobox');
+    await user.click(select);
+
+    const option = screen.getByText('회의실 A (최대 10인)');
+    await user.click(option);
+
+    expect(handleChange).toHaveBeenCalledWith('room-1');
+  });
+
+  it('disabled 상태일 때 선택이 불가해야 함', () => {
+    render(
+      <RoomSelector
+        rooms={mockRooms}
+        selectedRoomId={null}
+        onChange={vi.fn()}
+        disabled
+      />,
+    );
+
+    const select = screen.getByRole('combobox');
+    expect(select).toBeDisabled();
+  });
+
+  it('helper text를 올바르게 표시해야 함', () => {
+    render(
+      <RoomSelector
+        rooms={mockRooms}
+        selectedRoomId={null}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('확정할 회의실을 선택하세요')).toBeInTheDocument();
+  });
+
+  it('선택된 회의실이 올바르게 표시되어야 함', () => {
+    render(
+      <RoomSelector
+        rooms={mockRooms}
+        selectedRoomId="room-2"
+        onChange={vi.fn()}
+      />,
+    );
+
+    const select = screen.getByRole('combobox') as HTMLInputElement;
+    expect(select.value).toBe('room-2');
+  });
+});

--- a/apps/web/src/components/section-header.test.tsx
+++ b/apps/web/src/components/section-header.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import SectionHeader from './section-header';
+
+describe('SectionHeader', () => {
+  // 제목 렌더링 테스트
+  it('제목을 렌더링해야 함', () => {
+    render(<SectionHeader title="면접 일정" />);
+
+    const title = screen.getByRole('heading', { name: '면접 일정' });
+    expect(title).toBeInTheDocument();
+  });
+
+  it('제목을 h2 요소로 렌더링해야 함', () => {
+    render(<SectionHeader title="면접 일정" />);
+
+    const title = screen.getByRole('heading', { level: 2, name: '면접 일정' });
+    expect(title).toBeInTheDocument();
+  });
+
+  // 서브타이틀 렌더링 테스트
+  it('서브타이틀을 렌더링해야 함', () => {
+    render(
+      <SectionHeader
+        title="면접 일정"
+        subtitle="2026년 1월 13일 ~ 1월 15일"
+      />,
+    );
+
+    const subtitle = screen.getByText('2026년 1월 13일 ~ 1월 15일');
+    expect(subtitle).toBeInTheDocument();
+  });
+
+  it('서브타이틀이 제공되지 않으면 렌더링하지 않아야 함', () => {
+    render(<SectionHeader title="면접 일정" />);
+
+    const subtitle = screen.queryByText(/2026/);
+    expect(subtitle).not.toBeInTheDocument();
+  });
+
+  // 액션 버튼 렌더링 테스트
+  it('액션 버튼을 렌더링해야 함', () => {
+    const action = <button type="button">버튼</button>;
+    render(<SectionHeader title="면접 일정" action={action} />);
+
+    const button = screen.getByRole('button', { name: '버튼' });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('액션이 제공되지 않으면 렌더링하지 않아야 함', () {
+    render(<SectionHeader title="면접 일정" />);
+
+    const button = screen.queryByRole('button');
+    expect(button).not.toBeInTheDocument();
+  });
+
+  // 레이아웃 구조 테스트
+  it('제목과 액션을 같은 행에 렌더링해야 함', () => {
+    const action = <button type="button">액션</button>;
+    render(<SectionHeader title="제목" action={action} />);
+
+    const title = screen.getByRole('heading');
+    const button = screen.getByRole('button');
+    expect(title).toBeInTheDocument();
+    expect(button).toBeInTheDocument();
+  });
+
+  // 모든 요소 통합 테스트
+  it('제목, 서브타이틀, 액션을 모두 렌더링해야 함', () => {
+    const action = <button type="button">새로 만들기</button>;
+    render(
+      <SectionHeader
+        title="회의 목록"
+        subtitle="총 5개의 회의"
+        action={action}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: '회의 목록' })).toBeInTheDocument();
+    expect(screen.getByText('총 5개의 회의')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '새로 만들기' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/status-chip.test.tsx
+++ b/apps/web/src/components/status-chip.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import StatusChip from './status-chip';
+
+describe('StatusChip', () => {
+  // 상태별 렌더링 테스트
+  it('성공 상태를 올바르게 렌더링해야 함', () => {
+    render(<StatusChip status="success" label="응답 완료" />);
+
+    const chip = screen.getByText('응답 완료');
+    expect(chip).toBeInTheDocument();
+  });
+
+  it('경고 상태를 올바르게 렌더링해야 함', () => {
+    render(<StatusChip status="warning" label="대기 중" />);
+
+    const chip = screen.getByText('대기 중');
+    expect(chip).toBeInTheDocument();
+  });
+
+  it('에러 상태를 올바르게 렌더링해야 함', () => {
+    render(<StatusChip status="error" label="거절됨" />);
+
+    const chip = screen.getByText('거절됨');
+    expect(chip).toBeInTheDocument();
+  });
+
+  it('기본 상태를 올바르게 렌더링해야 함', () => {
+    render(<StatusChip status="default" label="기본" />);
+
+    const chip = screen.getByText('기본');
+    expect(chip).toBeInTheDocument();
+  });
+
+  it('차단 상태를 올바르게 렌더링해야 함', () => {
+    render(<StatusChip status="blocked" label="차단됨" />);
+
+    const chip = screen.getByText('차단됨');
+    expect(chip).toBeInTheDocument();
+  });
+
+  // 크기 테스트
+  it('small 사이즈를 올바르게 렌더링해야 함', () => {
+    render(<StatusChip status="success" label="작은 칩" size="small" />);
+
+    const chip = screen.getByText('작은 칩');
+    expect(chip).toBeInTheDocument();
+  });
+
+  it('medium 사이즈를 올바르게 렌더링해야 함', () => {
+    render(<StatusChip status="success" label="중간 칩" size="medium" />);
+
+    const chip = screen.getByText('중간 칩');
+    expect(chip).toBeInTheDocument();
+  });
+
+  it('기본 사이즈가 medium이어야 함', () => {
+    render(<StatusChip status="success" label="기본 칩" />);
+
+    const chip = screen.getByText('기본 칩');
+    expect(chip).toBeInTheDocument();
+  });
+
+  // 스타일 테스트
+  it('차단 상태일 때 opacity가 0.5여야 함', () => {
+    render(<StatusChip status="blocked" label="차단됨" />);
+
+    const chip = screen.getByText('차단됨');
+    expect(chip).toHaveStyle({ opacity: 0.5 });
+  });
+
+  it('차단 상태가 아닐 때 opacity가 적용되지 않아야 함', () => {
+    render(<StatusChip status="success" label="활성" />);
+
+    const chip = screen.getByText('활성');
+    expect(chip).not.toHaveStyle({ opacity: 0.5 });
+  });
+});

--- a/apps/web/src/components/sticky-action-bar.test.tsx
+++ b/apps/web/src/components/sticky-action-bar.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import StickyActionBar from './sticky-action-bar';
+
+describe('StickyActionBar', () => {
+  it('하단에 고정된 위치를 가져야 함', () => {
+    render(
+      <StickyActionBar
+        label="확인"
+        onClick={vi.fn()}
+      />,
+    );
+    
+    const actionBar = screen.getByRole('button').parentElement;
+    expect(actionBar).toHaveStyle({
+      position: 'fixed',
+      bottom: '0px',
+      left: '0px',
+      right: '0px',
+    });
+  });
+
+  it('label이 표시되어야 함', () => {
+    render(
+      <StickyActionBar
+        label="다음 단계"
+        onClick={vi.fn()}
+      />,
+    );
+    
+    const button = screen.getByRole('button');
+    expect(button).toHaveTextContent('다음 단계');
+  });
+
+  it('disabled 상태일 때 버튼이 비활성화되어야 함', () => {
+    render(
+      <StickyActionBar
+        label="확인"
+        disabled={true}
+        onClick={vi.fn()}
+      />,
+    );
+    
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+  });
+
+  it('disabled가 false일 때 버튼이 활성화되어야 함', () => {
+    render(
+      <StickyActionBar
+        label="확인"
+        disabled={false}
+        onClick={vi.fn()}
+      />,
+    );
+    
+    const button = screen.getByRole('button');
+    expect(button).not.toBeDisabled();
+  });
+
+  it('selectedCount가 0이면 개수가 표시되지 않아야 함', () => {
+    render(
+      <StickyActionBar
+        label="확인"
+        onClick={vi.fn()}
+        selectedCount={0}
+      />,
+    );
+    
+    const button = screen.getByRole('button');
+    expect(button).toHaveTextContent('확인');
+    expect(button).not.toHaveTextContent('(0개 선택)');
+  });
+
+  it('selectedCount가 양수이면 개수가 표시되어야 함', () => {
+    render(
+      <StickyActionBar
+        label="확인"
+        onClick={vi.fn()}
+        selectedCount={3}
+      />,
+    );
+    
+    const button = screen.getByRole('button');
+    expect(button).toHaveTextContent('확인 (3개 선택)');
+  });
+
+  it('클릭 시 onClick 핸들러가 호출되어야 함', async () => {
+    const handleClick = vi.fn();
+    const user = userEvent.setup();
+    
+    render(
+      <StickyActionBar
+        label="확인"
+        onClick={handleClick}
+      />,
+    );
+    
+    const button = screen.getByRole('button');
+    await user.click(button);
+    
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/time-grid.test.tsx
+++ b/apps/web/src/components/time-grid.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TimeGrid from './time-grid';
+
+describe('TimeGrid', () => {
+  const mockSlots = [
+    { time: '09:00', status: 'available' as const },
+    { time: '09:30', status: 'unavailable' as const },
+    { time: '10:00', status: 'blocked' as const, blockedReason: '점심시간' },
+  ];
+
+  it('날짜를 한국어 형식으로 렌더링해야 함', () => {
+    render(
+      <TimeGrid
+        date="2026-01-13"
+        slots={mockSlots}
+        onSlotClick={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/1월/)).toBeInTheDocument();
+    expect(screen.getByText(/13일/)).toBeInTheDocument();
+    expect(screen.getByText(/화요일/)).toBeInTheDocument();
+  });
+
+  it('모든 슬롯을 올바르게 렌더링해야 함', () => {
+    render(
+      <TimeGrid
+        date="2026-01-13"
+        slots={mockSlots}
+        onSlotClick={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('09:00')).toBeInTheDocument();
+    expect(screen.getByText('09:30')).toBeInTheDocument();
+    expect(screen.getByText('10:00')).toBeInTheDocument();
+  });
+
+  it('슬롯 클릭 시 onSlotClick을 올바른 시간으로 호출해야 함', async () => {
+    const user = userEvent.setup();
+    const handleSlotClick = vi.fn();
+
+    render(
+      <TimeGrid
+        date="2026-01-13"
+        slots={mockSlots}
+        onSlotClick={handleSlotClick}
+      />,
+    );
+
+    await user.click(screen.getByText('09:00'));
+
+    expect(handleSlotClick).toHaveBeenCalledWith('09:00');
+  });
+
+  it('전체 가능/불가 버튼을 렌더링해야 함', () => {
+    render(
+      <TimeGrid
+        date="2026-01-13"
+        slots={mockSlots}
+        onSlotClick={vi.fn()}
+        onToggleAllAvailable={vi.fn()}
+        onToggleAllUnavailable={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('전체 가능')).toBeInTheDocument();
+    expect(screen.getByText('전체 불가')).toBeInTheDocument();
+  });
+
+  it('전체 가능 버튼 클릭 시 onToggleAllAvailable을 호출해야 함', async () => {
+    const user = userEvent.setup();
+    const handleToggleAllAvailable = vi.fn();
+
+    render(
+      <TimeGrid
+        date="2026-01-13"
+        slots={mockSlots}
+        onSlotClick={vi.fn()}
+        onToggleAllAvailable={handleToggleAllAvailable}
+        onToggleAllUnavailable={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByText('전체 가능'));
+
+    expect(handleToggleAllAvailable).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/time-slot.test.tsx
+++ b/apps/web/src/components/time-slot.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TimeSlot from './time-slot';
+
+describe('TimeSlot', () => {
+  it('가능 상태를 올바른 스타일로 렌더링해야 함', () => {
+    render(<TimeSlot time="09:00" status="available" onClick={vi.fn()} />);
+
+    const slot = screen.getByText('09:00');
+    expect(slot).toBeInTheDocument();
+    expect(slot.closest('button')).toHaveStyle({
+      backgroundColor: '#e8f5e9',
+      color: '#2e7d32',
+      border: '2px solid #4caf50',
+    });
+  });
+
+  it('불가 상태를 올바른 스타일로 렌더링해야 함', () => {
+    render(<TimeSlot time="09:30" status="unavailable" onClick={vi.fn()} />);
+
+    const slot = screen.getByText('09:30');
+    expect(slot).toBeInTheDocument();
+    expect(slot.closest('button')).toHaveStyle({
+      backgroundColor: '#ffcdd2',
+      color: '#d32f2f',
+      border: '2px solid #f44336',
+    });
+  });
+
+  it('차단 상태를 올바른 스타일로 렌더링해야 함', () => {
+    render(
+      <TimeSlot
+        time="10:00"
+        status="blocked"
+        onClick={vi.fn()}
+        blockedReason="점심시간"
+      />,
+    );
+
+    const slot = screen.getByText('10:00');
+    expect(slot).toBeInTheDocument();
+    expect(slot.closest('button')).toHaveStyle({
+      backgroundColor: '#eeeeee',
+      color: '#9e9e9e',
+      border: '2px solid #e0e0e0',
+      opacity: '0.5',
+    });
+    expect(screen.getByText('점심시간')).toBeInTheDocument();
+  });
+
+  it('가능/불가 상태에서 클릭 시 onClick 핸들러를 호출해야 함', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(<TimeSlot time="09:00" status="available" onClick={handleClick} />);
+
+    const slot = screen.getByText('09:00');
+    await user.click(slot);
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('차단 상태에서는 클릭이 작동하지 않아야 함', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(
+      <TimeSlot time="10:00" status="blocked" onClick={handleClick} />,
+    );
+
+    const slot = screen.getByText('10:00');
+    await user.click(slot);
+
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/src/dto.ts
+++ b/packages/shared/src/dto.ts
@@ -13,6 +13,7 @@ export enum TimeSlotStatus {
 
 export interface CreateMeetingRequestDto {
   title: string;
+  description?: string;
   organizerId: string;
   participantIds: string[];
   requiredParticipantIds: string[];
@@ -44,15 +45,28 @@ export interface CreateParticipantResponseDto {
 export interface DashboardDto {
   requestId: string;
   title: string;
+  description?: string;
   status: MeetingRequestStatus;
-  participants: {
+  participants: Array<{
     userId: string;
     name: string;
+    department: string;
     responded: boolean;
-  }[];
-  commonAvailableSlots: string[];
+  }>;
+  commonAvailableSlots: Array<{
+    date: string;
+    times: string[];
+  }>;
   createdAt: string;
-  closedAt?: string;
+  startDate: string;
+  endDate: string;
+  durationMinutes: number;
+}
+
+export interface CreateMeetingResponse {
+  requestId: string;
+  meetingUrl: string;
+  responseUrl: string;
 }
 
 export interface RemindResponseDto {
@@ -62,8 +76,9 @@ export interface RemindResponseDto {
 
 export interface ConfirmMeetingDto {
   requestId: string;
-  selectedTimeSlot: string;
-  location?: string;
+  confirmedStart: string;
+  confirmedEnd: string;
+  roomId: string;
 }
 
 export interface ConfirmMeetingResponseDto {
@@ -72,6 +87,20 @@ export interface ConfirmMeetingResponseDto {
   selectedTimeSlot: string;
   location?: string;
   confirmedAt: string;
+}
+
+export interface SubmitResponseDto {
+  requestId: string;
+  userId: string;
+  name: string;
+  availableSlots: string[];
+  unavailableSlots: string[];
+}
+
+export interface HealthResponse {
+  status: string;
+  timestamp: string;
+  uptime: number;
 }
 
 export interface ErrorResponse {


### PR DESCRIPTION
## 변경 내용

### 프론트엔드 컴포넌트 (7개 완료)
- ✅ StatusChip - 상태 칩 컴포넌트
- ✅ MeetingCard - 회의 카드
- ✅ ParticipantList - 참석자 리스트
- ✅ TimeGrid - 시간 그리드
- ✅ TimeSlot - 시간 슬롯
- ✅ RoomSelector - 회의실 선택
- ✅ CommonSlots - 공통 가능 시간 리스트
- ✅ FloatingButton - 플로팅 버튼
- ✅ StickyActionBar - 고정 하단 액션바

### 페이지 MUI 리팩터링 (4개 완료)
- ✅ HomePage - MeetingCard, FloatingButton 적용
- ✅ DashboardPage - ParticipantList, CommonSlots, RoomSelector 적용
- ✅ ResponsePage - TimeGrid, StickyActionBar 적용
- ✅ CreatePage - MUI TextField, Button, Grid 적용

### API 래퍼 (2개 완료)
- ✅ health.ts - checkHealth 함수
- ✅ meeting.ts - fetchDashboard, createMeeting, submitResponse, sendReminder, confirmMeeting

### @shared/dto 확장
- ✅ HealthResponse 타입 추가
- ✅ SubmitResponseDto 타입 추가
- ✅ DashboardDto 확장 (description, participants, commonAvailableSlots 구조 수정)
- ✅ CreateMeetingRequestDto 확장 (description 추가)
- ✅ ConfirmMeetingDto 업데이트 (confirmedStart, confirmedEnd, roomId)
- ✅ CreateMeetingResponse 타입 추가

### 테스트 파일 (16개 추가)
- ✅ 컴포넌트 테스트: status-chip, section-header, progress-bar, loading-state, empty-state, floating-button, sticky-action-bar
- ✅ 복잡 컴포넌트: time-slot, time-grid, room-selector, participant-list, meeting-card, common-slots
- ✅ API 테스트: health.test.ts, meeting.test.ts

### 개발 스크립트 (3개)
- ✅ setup-dev-env.sh - 개발 환경 자동 설정
- ✅ stop-dev-env.sh - 개발 환경 중지
- ✅ reset-db.sh - 데이터베이스 리셋

### 문서 업데이트
- ✅ work-history/TEMPLATE.md - 토큰 사용량 추적 섹션 추가
- ✅ README.md - 빠른 시작 섹션 추가 (스크립트 사용법)
- ✅ work-history/2026-01-13-current-status.md - 프로젝트 현황 문서

## 검증 방법

### 1. 개발 서버 실행
\`\`\`bash
./scripts/setup-dev-env.sh
# 또는
pnpm run dev
\`\`\`

### 2. 각 페이지 테스트
- **HomePage**: http://localhost:5173/ - 헬스체크 확인
- **CreatePage**: http://localhost:5173/requests/new - 회의 생성 테스트
- **DashboardPage**: http://localhost:5173/requests/:id/dashboard - 대시보드 확인
- **ResponsePage**: http://localhost:5173/requests/:id/respond - 응답 제출 테스트

### 3. API 엔드포인트 테스트
- GET /api/health - 헬스체크
- POST /api/meetings - 회의 생성
- GET /api/meetings/:id/dashboard - 대시보드 조회
- POST /api/meetings/:id/respond - 응답 제출
- POST /api/meetings/:id/remind/:userId - 리마인드 전송
- POST /api/meetings/:id/confirm - 회의 확정

### 4. 테스트 실행
\`\`\`bash
# 전체 테스트
pnpm test

# 웹 패키지 테스트
pnpm --filter web test

# 특정 파일 테스트
pnpm test apps/web/src/components/status-chip.test.tsx
\`\`\`

## 참고 사항

- 모든 컴포넌트는 MUI(Material-UI)를 기반으로 작성되었습니다.
- API 래퍼는 fetch API를 사용하며, 향후 TanStack Query로 교체 계획입니다.
- @shared/dto는 백엔드와 프론트엔드에서 타입을 공유하기 위한 패키지입니다.
- 테스트는 Vitest + React Testing Library를 사용합니다.

## 관련 커밋

- 2026-01-13: feat: 프론트엔드 컴포넌트 구현 (컴포넌트 7개)
- 2026-01-13: refactor: 페이지에 MUI 컴포넌트 적용 (페이지 4개)
- 2026-01-13: feat: API 래퍼 구현 (health, meeting)
- 2026-01-13: test: 프론트엔드 테스트 파일 16개 추가