### PR TITLE
fix: 소요시간 드롭다운 정상화 및 전체 시간 슬롯 생성

### DIFF
--- a/apps/api/src/modules/meeting/meeting.service.ts
+++ b/apps/api/src/modules/meeting/meeting.service.ts
@@ -229,21 +229,24 @@ export class MeetingService {
 
     while (current <= end) {
       const isHoliday = await this.holidayAdapter.isHoliday(current);
+      const slotsToCreate = [];
 
       for (let hour = 0; hour < 24; hour++) {
         for (let minute = 0; minute < 60; minute += 30) {
           const slotTime = new Date(current);
           slotTime.setHours(hour, minute, 0, 0);
 
-          await this.prisma.timeSlot.create({
-            data: {
-              requestId,
-              slotDate: slotTime,
-              status: isHoliday ? SlotStatus.BLOCKED : SlotStatus.AVAILABLE,
-            },
+          slotsToCreate.push({
+            requestId,
+            slotDate: slotTime,
+            status: isHoliday ? SlotStatus.BLOCKED : SlotStatus.AVAILABLE,
           });
         }
       }
+
+      await this.prisma.timeSlot.createMany({
+        data: slotsToCreate,
+      });
 
       current.setDate(current.getDate() + 1);
     }

--- a/apps/api/src/modules/meeting/meeting.service.ts
+++ b/apps/api/src/modules/meeting/meeting.service.ts
@@ -228,26 +228,20 @@ export class MeetingService {
     end.setHours(23, 59, 59, 999);
 
     while (current <= end) {
-      const dayOfWeek = current.getDay();
+      const isHoliday = await this.holidayAdapter.isHoliday(current);
 
-      if (dayOfWeek !== 0 && dayOfWeek !== 6) {
-        const isHoliday = await this.holidayAdapter.isHoliday(current);
+      for (let hour = 0; hour < 24; hour++) {
+        for (let minute = 0; minute < 60; minute += 30) {
+          const slotTime = new Date(current);
+          slotTime.setHours(hour, minute, 0, 0);
 
-        for (let hour = 9; hour < 18; hour++) {
-          if (hour === 12) continue;
-
-          for (let minute = 0; minute < 60; minute += 30) {
-            const slotTime = new Date(current);
-            slotTime.setHours(hour, minute, 0, 0);
-
-            await this.prisma.timeSlot.create({
-              data: {
-                requestId,
-                slotDate: slotTime,
-                status: isHoliday ? SlotStatus.BLOCKED : SlotStatus.AVAILABLE,
-              },
-            });
-          }
+          await this.prisma.timeSlot.create({
+            data: {
+              requestId,
+              slotDate: slotTime,
+              status: isHoliday ? SlotStatus.BLOCKED : SlotStatus.AVAILABLE,
+            },
+          });
         }
       }
 

--- a/apps/web/src/pages/CreatePage.tsx
+++ b/apps/web/src/pages/CreatePage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { AppBar, Toolbar, IconButton, Typography, Box, Button, TextField, Container } from '@mui/material';
+import { AppBar, Toolbar, IconButton, Typography, Box, Button, TextField, Container, MenuItem } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 
 interface ParticipantInput {
@@ -184,11 +184,11 @@ export default function CreatePage() {
             onChange={(e) => setDurationMinutes(Number(e.target.value))}
             disabled={isSubmitting}
           >
-            <option value={30}>30분</option>
-            <option value={60}>1시간</option>
-            <option value={90}>1시간 30분</option>
-            <option value={120}>2시간</option>
-            <option value={180}>3시간</option>
+            <MenuItem value={30}>30분</MenuItem>
+            <MenuItem value={60}>1시간</MenuItem>
+            <MenuItem value={90}>1시간 30분</MenuItem>
+            <MenuItem value={120}>2시간</MenuItem>
+            <MenuItem value={180}>3시간</MenuItem>
           </TextField>
         </Box>
 
@@ -209,10 +209,9 @@ export default function CreatePage() {
           </Typography>
           <Typography variant="body2" component="div">
             <ul style={{ margin: 0, paddingLeft: '1.5rem' }}>
-              <li>회의 시간은 09:00-18:00 사이 30분 단위로만 가능합니다.</li>
-              <li>점심시간(12:00-13:00)은 자동으로 제외됩니다.</li>
+              <li>회의 시간은 30분 단위로 생성됩니다.</li>
+              <li>시간/요일 제한은 추후 옵션으로 제공할 수 있습니다.</li>
               <li>생성 후 대시보드에서 참석자들에게 응답 링크를 공유하세요.</li>
-              <li>주말은 제외됩니다.</li>
             </ul>
           </Typography>
         </Box>

--- a/apps/web/src/pages/CreatePage.tsx
+++ b/apps/web/src/pages/CreatePage.tsx
@@ -8,6 +8,14 @@ interface ParticipantInput {
   name: string;
 }
 
+const DURATION_OPTIONS = [
+  { value: 30, label: '30분' },
+  { value: 60, label: '1시간' },
+  { value: 90, label: '1시간 30분' },
+  { value: 120, label: '2시간' },
+  { value: 180, label: '3시간' },
+];
+
 export default function CreatePage() {
   const navigate = useNavigate();
   const [title, setTitle] = useState('');
@@ -184,11 +192,11 @@ export default function CreatePage() {
             onChange={(e) => setDurationMinutes(Number(e.target.value))}
             disabled={isSubmitting}
           >
-            <MenuItem value={30}>30분</MenuItem>
-            <MenuItem value={60}>1시간</MenuItem>
-            <MenuItem value={90}>1시간 30분</MenuItem>
-            <MenuItem value={120}>2시간</MenuItem>
-            <MenuItem value={180}>3시간</MenuItem>
+            {DURATION_OPTIONS.map((option) => (
+              <MenuItem key={option.value} value={option.value}>
+                {option.label}
+              </MenuItem>
+            ))}
           </TextField>
         </Box>
 


### PR DESCRIPTION
## 요약
- CreatePage의 소요시간 선택 드롭다운이 깨지는 문제를 수정 (MUI Select에 `MenuItem` 사용)
- API 슬롯 생성 규칙을 30분 단위 전체 시간(00:00-23:30) 생성으로 변경

## 참고
- holiday adapter는 그대로 유지되며 공휴일은 `BLOCKED` 처리
- develop에 기존 TypeScript/test 이슈가 있어 web build는 현재 실패할 수 있음(본 PR 범위 밖)