### PR TITLE
feat: 주최자 시간 선택 기능 추가

### DIFF
--- a/apps/api/src/modules/meeting/meeting.service.spec.ts
+++ b/apps/api/src/modules/meeting/meeting.service.spec.ts
@@ -97,6 +97,123 @@ describe('MeetingService', () => {
       (prisma.meetingRequest.findUnique as jest.Mock).mockResolvedValue(mockRequest);
     });
   });
+
+  describe('주최자 시간 선택', () => {
+    it('주최자 시간 슬롯 업데이트', async () => {
+      const mockRequest = {
+        id: 'test-request-id',
+        title: 'Test Meeting',
+        organizerId: 'user-1',
+        startDate: new Date('2026-01-20'),
+        endDate: new Date('2026-01-21'),
+        durationMinutes: 60,
+        status: 'OPEN',
+        createdAt: new Date(),
+      };
+
+      (prisma.meetingRequest.create as jest.Mock).mockResolvedValue(mockRequest);
+      (prisma.timeSlot.createMany as jest.Mock).mockResolvedValue({ count: 96 });
+      (prisma.timeSlot.updateMany as jest.Mock).mockResolvedValue({ count: 50 });
+
+      const dto: CreateMeetingRequestDto = {
+        title: 'Test Meeting',
+        organizerId: 'user-1',
+        participantIds: ['user-2'],
+        requiredParticipantIds: ['user-2'],
+        startDate: '2026-01-20',
+        endDate: '2026-01-21',
+        durationMinutes: 60,
+        organizerAvailableSlots: [
+          '2026-01-20T09:00:00Z',
+          '2026-01-20T10:00:00Z',
+          '2026-01-20T14:00:00Z',
+        ],
+      };
+
+      await service.createRequest(dto);
+
+      expect(prisma.timeSlot.updateMany).toHaveBeenCalledWith({
+        where: {
+          requestId: 'test-request-id',
+          participantId: null,
+          status: 'AVAILABLE',
+          slotDate: {
+            notIn: [
+              new Date('2026-01-20T09:00:00Z'),
+              new Date('2026-01-20T10:00:00Z'),
+              new Date('2026-01-20T14:00:00Z'),
+            ],
+          },
+        },
+        data: { status: 'UNAVAILABLE' },
+      });
+    });
+
+    it('주최자 시간 없으면 모든 슬롯 유지', async () => {
+      const mockRequest = {
+        id: 'test-request-id',
+        title: 'Test Meeting',
+        organizerId: 'user-1',
+        startDate: new Date('2026-01-20'),
+        endDate: new Date('2026-01-21'),
+        durationMinutes: 60,
+        status: 'OPEN',
+        createdAt: new Date(),
+      };
+
+      (prisma.meetingRequest.create as jest.Mock).mockResolvedValue(mockRequest);
+      (prisma.timeSlot.createMany as jest.Mock).mockResolvedValue({ count: 96 });
+      (prisma.timeSlot.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
+
+      const dto: CreateMeetingRequestDto = {
+        title: 'Test Meeting',
+        organizerId: 'user-1',
+        participantIds: ['user-2'],
+        requiredParticipantIds: ['user-2'],
+        startDate: '2026-01-20',
+        endDate: '2026-01-21',
+        durationMinutes: 60,
+        organizerAvailableSlots: [],
+      };
+
+      await service.createRequest(dto);
+
+      expect(prisma.timeSlot.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('대시보드에 주최자 시간 슬롯 반환', async () => {
+      const mockRequest = {
+        id: 'test-request-id',
+        title: 'Test Meeting',
+        status: 'OPEN',
+        participants: [],
+        createdAt: new Date('2026-01-20'),
+        startDate: new Date('2026-01-20'),
+        endDate: new Date('2026-01-21'),
+        durationMinutes: 60,
+      };
+
+      const mockOrganizerSlots = [
+        { slotDate: new Date('2026-01-20T09:00:00Z') },
+        { slotDate: new Date('2026-01-20T10:00:00Z') },
+        { slotDate: new Date('2026-01-20T14:00:00Z') },
+      ];
+
+      (prisma.meetingRequest.findUnique as jest.Mock).mockResolvedValue(mockRequest);
+      (prisma.timeSlot.findMany as jest.Mock)
+        .mockResolvedValueOnce(mockOrganizerSlots)
+        .mockResolvedValueOnce([]);
+      (prisma.participant.findMany as jest.Mock).mockResolvedValue([]);
+
+      const result = await service.getDashboard('test-request-id');
+
+      expect(result.organizerAvailableSlots).toEqual([
+        '2026-01-20T09:00:00.000Z',
+        '2026-01-20T10:00:00.000Z',
+        '2026-01-20T14:00:00.000Z',
+      ]);
+    });
+  });
 });
 
 class RoomAdapterMock implements IRoomAdapter {

--- a/apps/api/src/modules/meeting/meeting.service.ts
+++ b/apps/api/src/modules/meeting/meeting.service.ts
@@ -51,6 +51,10 @@ export class MeetingService {
 
     await this.generateTimeSlots(request.id, request.startDate, request.endDate);
 
+    if (dto.organizerAvailableSlots && dto.organizerAvailableSlots.length > 0) {
+      await this.updateOrganizerAvailability(request.id, dto.organizerAvailableSlots);
+    }
+
     return {
       id: request.id,
       title: request.title,
@@ -91,6 +95,15 @@ export class MeetingService {
       }))
       .sort((a, b) => a.date.localeCompare(b.date));
 
+    const organizerSlots = await this.prisma.timeSlot.findMany({
+      where: {
+        requestId,
+        participantId: null,
+        status: SlotStatus.AVAILABLE,
+      },
+      select: { slotDate: true },
+    });
+
     return {
       requestId: request.id,
       title: request.title,
@@ -101,6 +114,7 @@ export class MeetingService {
         responded: p.responded,
       })),
       commonAvailableSlots,
+      organizerAvailableSlots: organizerSlots.map((s) => s.slotDate.toISOString()),
       createdAt: request.createdAt.toISOString(),
       startDate: request.startDate.toISOString(),
       endDate: request.endDate.toISOString(),
@@ -266,6 +280,22 @@ export class MeetingService {
 
       current.setDate(current.getDate() + 1);
     }
+  }
+
+  private async updateOrganizerAvailability(requestId: string, availableSlots: string[]) {
+    await this.prisma.$transaction(async (tx) => {
+      await tx.timeSlot.updateMany({
+        where: {
+          requestId,
+          participantId: null,
+          status: SlotStatus.AVAILABLE,
+          slotDate: {
+            notIn: availableSlots.map((s) => new Date(s)),
+          },
+        },
+        data: { status: SlotStatus.UNAVAILABLE },
+      });
+    });
   }
 
   private async findCommonAvailableSlots(requestId: string): Promise<string[]> {

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -7,7 +7,9 @@
     "paths": {
       "@shared/*": ["../../packages/shared/dist"],
       "@shared/dto": ["../../packages/shared/dist/dto"]
-    }
+    },
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
   },
   "references": [
     { "path": "../../packages/shared" }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route } from 'react-router-dom';
 import HomePage from './pages/HomePage';
 import CreatePage from './pages/CreatePage';
+import OrganizerSlotSelectionPage from './pages/OrganizerSlotSelectionPage';
 import DashboardPage from './pages/DashboardPage';
 import ResponsePage from './pages/ResponsePage';
 
@@ -8,7 +9,9 @@ function App() {
   return (
     <Routes>
       <Route path="/" element={<HomePage />} />
+      <Route path="/new" element={<CreatePage />} />
       <Route path="/requests/new" element={<CreatePage />} />
+      <Route path="/requests/new/slots" element={<OrganizerSlotSelectionPage />} />
       <Route path="/requests/:id/dashboard" element={<DashboardPage />} />
       <Route path="/requests/:id/respond" element={<ResponsePage />} />
     </Routes>

--- a/apps/web/src/pages/CreatePage.test.tsx
+++ b/apps/web/src/pages/CreatePage.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import CreatePage from './CreatePage';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -74,7 +74,8 @@ describe('CreatePage', () => {
 
   it('회의 요청 생성 버튼이 있어야 한다', () => {
     renderWithProviders(<CreatePage />);
-    expect(screen.getByRole('button', { name: '회의 요청 생성' })).toBeInTheDocument();
+    const submitButton = screen.getByRole('button', { name: '다음: 시간 선택' });
+    expect(submitButton).toBeInTheDocument();
   });
 
   it('제목을 입력할 수 있어야 한다', () => {

--- a/apps/web/src/pages/CreatePage.test.tsx
+++ b/apps/web/src/pages/CreatePage.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import CreatePage from './CreatePage';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -72,7 +72,7 @@ describe('CreatePage', () => {
     expect(screen.getByLabelText('소요시간 *')).toBeInTheDocument();
   });
 
-  it('회의 요청 생성 버튼이 있어야 한다', () => {
+  it('다음: 시간 선택 버튼이 있어야 한다', () => {
     renderWithProviders(<CreatePage />);
     const submitButton = screen.getByRole('button', { name: '다음: 시간 선택' });
     expect(submitButton).toBeInTheDocument();

--- a/apps/web/src/pages/CreatePage.tsx
+++ b/apps/web/src/pages/CreatePage.tsx
@@ -182,7 +182,7 @@ export default function CreatePage() {
           onClick={handleSubmit}
           sx={{ mb: 2 }}
         >
-          다음: 시간 선택
+          회의 요청 생성
         </Button>
 
         <Box sx={{ p: 2, backgroundColor: 'grey.100', borderRadius: 1 }}>

--- a/apps/web/src/pages/CreatePage.tsx
+++ b/apps/web/src/pages/CreatePage.tsx
@@ -26,7 +26,6 @@ export default function CreatePage() {
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
   const [durationMinutes, setDurationMinutes] = useState(60);
-  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleAddParticipant = () => {
     setParticipants([...participants, { email: '', name: '' }]);
@@ -44,7 +43,7 @@ export default function CreatePage() {
     setParticipants(updated);
   };
 
-  const handleSubmit = async () => {
+  const handleSubmit = () => {
     if (!title || !startDate || !endDate) {
       alert('필수 정보를 모두 입력해주세요.');
       return;
@@ -56,35 +55,21 @@ export default function CreatePage() {
       return;
     }
 
-    setIsSubmitting(true);
-    try {
-      const response = await fetch('/api/meetings', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          title,
-          description,
-          organizerId: 'organizer-1',
-          participantIds: validParticipants.map((p) => p.email),
-          startDate,
-          endDate,
-          durationMinutes,
-        }),
+    const meetingData = {
+      title,
+      description,
+      organizerId: 'organizer-1',
+      participantIds: validParticipants.map((p) => p.email),
+      requiredParticipantIds: [],
+      startDate,
+      endDate,
+      durationMinutes,
+      location: '',
+    };
+
+      navigate('/requests/new/slots', {
+        state: { meetingData },
       });
-
-      if (!response.ok) {
-        throw new Error('Failed to create meeting');
-      }
-
-      const data = await response.json();
-
-      alert(`회의 요청이 생성되었습니다!\n\n대시보드 링크:\n${window.location.origin}/requests/${data.id}/dashboard`);
-      navigate(`/requests/${data.id}/dashboard`);
-    } catch (_error) {
-      alert('회의 요청 생성에 실패했습니다.');
-    } finally {
-      setIsSubmitting(false);
-    }
   };
 
   return (
@@ -108,7 +93,6 @@ export default function CreatePage() {
           onChange={(e) => setTitle(e.target.value)}
           placeholder="예: 팀 주간회의"
           sx={{ mb: 3 }}
-          disabled={isSubmitting}
         />
 
         <TextField
@@ -120,7 +104,6 @@ export default function CreatePage() {
           multiline
           rows={3}
           sx={{ mb: 3 }}
-          disabled={isSubmitting}
         />
 
         <Typography variant="subtitle1" gutterBottom fontWeight="bold" sx={{ mb: 2 }}>
@@ -135,7 +118,6 @@ export default function CreatePage() {
                 value={participant.email}
                 onChange={(e) => handleParticipantChange(index, 'email', e.target.value)}
                 sx={{ flex: 1 }}
-                disabled={isSubmitting}
               />
               <TextField
                 type="text"
@@ -143,14 +125,12 @@ export default function CreatePage() {
                 value={participant.name}
                 onChange={(e) => handleParticipantChange(index, 'name', e.target.value)}
                 sx={{ flex: 1 }}
-                disabled={isSubmitting}
               />
               {participants.length > 1 && (
                 <Button
                   variant="contained"
                   color="error"
                   onClick={() => handleRemoveParticipant(index)}
-                  disabled={isSubmitting}
                 >
                   삭제
                 </Button>
@@ -161,7 +141,6 @@ export default function CreatePage() {
             variant="outlined"
             onClick={handleAddParticipant}
             startIcon={<span>+</span>}
-            disabled={isSubmitting}
           >
             참석자 추가
           </Button>
@@ -174,7 +153,6 @@ export default function CreatePage() {
             value={startDate}
             onChange={(e) => setStartDate(e.target.value)}
             InputLabelProps={{ shrink: true }}
-            disabled={isSubmitting}
           />
           <TextField
             type="date"
@@ -182,14 +160,12 @@ export default function CreatePage() {
             value={endDate}
             onChange={(e) => setEndDate(e.target.value)}
             InputLabelProps={{ shrink: true }}
-            disabled={isSubmitting}
           />
           <TextField
             select
             label="소요시간 *"
             value={durationMinutes}
             onChange={(e) => setDurationMinutes(Number(e.target.value))}
-            disabled={isSubmitting}
           >
             {DURATION_OPTIONS.map((option) => (
               <MenuItem key={option.value} value={option.value}>
@@ -204,10 +180,9 @@ export default function CreatePage() {
           fullWidth
           size="large"
           onClick={handleSubmit}
-          disabled={isSubmitting}
           sx={{ mb: 2 }}
         >
-          {isSubmitting ? '생성 중...' : '회의 요청 생성'}
+          다음: 시간 선택
         </Button>
 
         <Box sx={{ p: 2, backgroundColor: 'grey.100', borderRadius: 1 }}>

--- a/apps/web/src/pages/CreatePage.tsx
+++ b/apps/web/src/pages/CreatePage.tsx
@@ -182,7 +182,7 @@ export default function CreatePage() {
           onClick={handleSubmit}
           sx={{ mb: 2 }}
         >
-          회의 요청 생성
+          다음: 시간 선택
         </Button>
 
         <Box sx={{ p: 2, backgroundColor: 'grey.100', borderRadius: 1 }}>

--- a/apps/web/src/pages/OrganizerSlotSelectionPage.tsx
+++ b/apps/web/src/pages/OrganizerSlotSelectionPage.tsx
@@ -1,0 +1,306 @@
+import { useState, useMemo, useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { AppBar, Toolbar, IconButton, Typography, Box, Button, CircularProgress } from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+
+interface TimeSlotData {
+  date: string;
+  slots: string[];
+}
+
+interface MeetingFormData {
+  title: string;
+  description?: string;
+  organizerId: string;
+  participantIds: string[];
+  requiredParticipantIds: string[];
+  startDate: string;
+  endDate: string;
+  durationMinutes: number;
+  location?: string;
+}
+
+export default function OrganizerSlotSelectionPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const meetingData = location.state?.meetingData as MeetingFormData;
+
+  const [selectedSlots, setSelectedSlots] = useState<Record<string, boolean>>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!meetingData || !meetingData.title || !meetingData.startDate || !meetingData.endDate) {
+      alert('회의 정보가 없습니다. 다시 생성해주세요.');
+      navigate('/new');
+      return;
+    }
+  }, [meetingData, navigate]);
+
+  const startDateString = meetingData?.startDate;
+  const endDateString = meetingData?.endDate;
+
+  const timeSlotData = useMemo<TimeSlotData[]>(() => {
+    if (!startDateString || !endDateString) return [];
+
+    const startDate = new Date(startDateString);
+    const endDate = new Date(endDateString);
+
+    if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+      return [];
+    }
+
+    const dates: string[] = [];
+    const current = new Date(startDate);
+    current.setHours(0, 0, 0, 0);
+
+    const end = new Date(endDate);
+    end.setHours(0, 0, 0, 0);
+
+    while (current <= end) {
+      const dayOfWeek = current.getDay();
+      if (dayOfWeek !== 0 && dayOfWeek !== 6) {
+        dates.push(current.toISOString());
+      }
+      current.setDate(current.getDate() + 1);
+    }
+
+    return dates.map((date) => {
+      const slots: string[] = [];
+
+      for (let hour = 9; hour < 18; hour++) {
+        if (hour === 12) continue;
+
+        for (let minute = 0; minute < 60; minute += 30) {
+          const timeStr = `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+          const slotDate = new Date(date);
+          slotDate.setHours(hour, minute, 0, 0);
+          slots.push(`${slotDate.toISOString()}|${timeStr}`);
+        }
+      }
+
+      return { date, slots };
+    });
+  }, [startDateString, endDateString]);
+
+  const isBlockedSlot = (date: string, time: string): boolean => {
+    const hour = parseInt(time.split(':')[0]);
+    const dayOfWeek = new Date(date).getDay();
+    return hour === 12 || dayOfWeek === 0 || dayOfWeek === 6;
+  };
+
+  const toggleSlot = (slotIso: string) => {
+    setSelectedSlots((prev) => {
+      const next = { ...prev };
+      if (next[slotIso]) {
+        delete next[slotIso];
+      } else {
+        next[slotIso] = true;
+      }
+      return next;
+    });
+  };
+
+  const handleSetAll = (date: string, value: boolean) => {
+    const dateSlots = timeSlotData.find((ds) => ds.date === date);
+    if (!dateSlots) return;
+
+    setSelectedSlots((prev) => {
+      const next = { ...prev };
+
+      dateSlots.slots.forEach((slot) => {
+        const [slotIso, time] = slot.split('|');
+        if (!slotIso || !time) return;
+        if (isBlockedSlot(date, time)) return;
+        if (value) {
+          next[slotIso] = true;
+        } else {
+          delete next[slotIso];
+        }
+      });
+
+      return next;
+    });
+  };
+
+  const handleSubmit = async () => {
+    if (!meetingData) return;
+
+    const selectedCount = Object.keys(selectedSlots).length;
+    if (selectedCount === 0) {
+      alert('최소 하나 이상의 시간을 선택해주세요.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const response = await fetch('/api/meetings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...meetingData,
+          organizerAvailableSlots: Object.keys(selectedSlots),
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to create meeting');
+      }
+
+      const data = await response.json();
+      alert(`회의 요청이 생성되었습니다!\n\n대시보드 링크:\n${window.location.origin}/requests/${data.id}/dashboard`);
+      navigate(`/requests/${data.id}/dashboard`);
+    } catch (_error) {
+      alert('회의 요청 생성에 실패했습니다.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!meetingData) {
+    return (
+      <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+        <AppBar position="static" color="default" elevation={0}>
+          <Toolbar>
+            <IconButton onClick={() => navigate('/')} color="inherit">
+              <ArrowBackIcon />
+            </IconButton>
+            <Typography variant="h6" component="div" sx={{ fontWeight: 600 }}>
+              시간 선택
+            </Typography>
+          </Toolbar>
+        </AppBar>
+        <Box sx={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '2rem' }}>
+          <CircularProgress />
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      <AppBar position="static" color="default" elevation={0}>
+        <Toolbar>
+          <IconButton onClick={() => navigate('/new')} color="inherit">
+            <ArrowBackIcon />
+          </IconButton>
+          <Typography variant="h6" component="div" sx={{ fontWeight: 600 }}>
+            시간 선택
+          </Typography>
+        </Toolbar>
+      </AppBar>
+
+      <Box sx={{ padding: '1rem', paddingBottom: '8rem', flex: 1 }}>
+        <Typography variant="h4" gutterBottom fontWeight={600}>
+          가능한 시간 선택
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ marginBottom: '1.5rem' }}>
+          회의를 진행할 수 있는 시간을 모두 선택해주세요.
+        </Typography>
+
+        <Box sx={{ marginBottom: '1.5rem', padding: '1rem', backgroundColor: '#f5f5f5', borderRadius: 1 }}>
+          <Typography variant="subtitle2" fontWeight="bold">
+            {meetingData.title}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {new Date(meetingData.startDate).toLocaleDateString('ko-KR')} - {new Date(meetingData.endDate).toLocaleDateString('ko-KR')} · {meetingData.durationMinutes}분
+          </Typography>
+        </Box>
+
+        {timeSlotData.map((dateSlot) => (
+          <Box key={dateSlot.date} sx={{ marginBottom: '1.5rem' }}>
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                marginBottom: '0.5rem',
+              }}
+            >
+              <Typography variant="h6" gutterBottom sx={{ margin: 0 }}>
+                {new Date(dateSlot.date).toLocaleDateString('ko-KR', { month: 'numeric', day: 'numeric', weekday: 'long' })}
+              </Typography>
+              <Box sx={{ display: 'flex', gap: '0.5rem' }}>
+                <Button
+                  size="small"
+                  variant="contained"
+                  color="success"
+                  onClick={() => handleSetAll(dateSlot.date, true)}
+                  disabled={isSubmitting}
+                >
+                  전체 선택
+                </Button>
+                <Button
+                  size="small"
+                  variant="contained"
+                  color="error"
+                  onClick={() => handleSetAll(dateSlot.date, false)}
+                  disabled={isSubmitting}
+                >
+                  전체 해제
+                </Button>
+              </Box>
+            </Box>
+
+            <Box sx={{ display: 'grid', gap: '0.5rem', gridTemplateColumns: 'repeat(auto-fill, minmax(80px, 1fr))' }}>
+              {dateSlot.slots.map((slot) => {
+                const [slotIso, time] = slot.split('|');
+                if (!slotIso || !time) return null;
+
+                const isSelected = selectedSlots[slotIso];
+                const isBlocked = isBlockedSlot(dateSlot.date, time);
+
+                return (
+                  <Button
+                    key={slotIso}
+                    disabled={isBlocked || isSubmitting}
+                    onClick={() => !isBlocked && toggleSlot(slotIso)}
+                    variant={isSelected ? 'contained' : 'outlined'}
+                    sx={{
+                      padding: '0.75rem',
+                      border: isSelected ? '3px solid #4caf50' : '2px solid #e0e0e0',
+                      borderRadius: '8px',
+                      backgroundColor: isSelected ? '#e8f5e9' : 'white',
+                      color: isSelected ? '#2e7d32' : '#333',
+                      fontWeight: 'bold',
+                      opacity: isBlocked ? 0.4 : 1,
+                      fontSize: '0.875rem',
+                      transition: 'transform 0.2s',
+                      '&:hover': {
+                        transform: isBlocked ? 'none' : 'scale(1.05)',
+                      },
+                    }}
+                  >
+                    {time}
+                  </Button>
+                );
+              })}
+            </Box>
+          </Box>
+        ))}
+
+        <Box
+          sx={{
+            position: 'fixed',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            padding: '1rem',
+            backgroundColor: 'white',
+            boxShadow: '0 -2px 10px rgba(0,0,0,0.1)',
+            textAlign: 'center',
+          }}
+        >
+          <Button
+            variant="contained"
+            fullWidth
+            size="large"
+            onClick={handleSubmit}
+            disabled={isSubmitting || Object.keys(selectedSlots).length === 0}
+          >
+            {isSubmitting ? '생성 중...' : `회의 생성 (${Object.keys(selectedSlots).length}개 선택)`}
+          </Button>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/web/src/pages/OrganizerSlotSelectionPage.tsx
+++ b/apps/web/src/pages/OrganizerSlotSelectionPage.tsx
@@ -1,12 +1,8 @@
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useEffect } from 'react';
+import { generateTimeSlots, isBlockedSlot, type TimeSlotData } from '../utils/timeSlot';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { AppBar, Toolbar, IconButton, Typography, Box, Button, CircularProgress } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-
-interface TimeSlotData {
-  date: string;
-  slots: string[];
-}
 
 interface MeetingFormData {
   title: string;
@@ -39,54 +35,7 @@ export default function OrganizerSlotSelectionPage() {
   const startDateString = meetingData?.startDate;
   const endDateString = meetingData?.endDate;
 
-  const timeSlotData = useMemo<TimeSlotData[]>(() => {
-    if (!startDateString || !endDateString) return [];
-
-    const startDate = new Date(startDateString);
-    const endDate = new Date(endDateString);
-
-    if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
-      return [];
-    }
-
-    const dates: string[] = [];
-    const current = new Date(startDate);
-    current.setHours(0, 0, 0, 0);
-
-    const end = new Date(endDate);
-    end.setHours(0, 0, 0, 0);
-
-    while (current <= end) {
-      const dayOfWeek = current.getDay();
-      if (dayOfWeek !== 0 && dayOfWeek !== 6) {
-        dates.push(current.toISOString());
-      }
-      current.setDate(current.getDate() + 1);
-    }
-
-    return dates.map((date) => {
-      const slots: string[] = [];
-
-      for (let hour = 9; hour < 18; hour++) {
-        if (hour === 12) continue;
-
-        for (let minute = 0; minute < 60; minute += 30) {
-          const timeStr = `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
-          const slotDate = new Date(date);
-          slotDate.setHours(hour, minute, 0, 0);
-          slots.push(`${slotDate.toISOString()}|${timeStr}`);
-        }
-      }
-
-      return { date, slots };
-    });
-  }, [startDateString, endDateString]);
-
-  const isBlockedSlot = (date: string, time: string): boolean => {
-    const hour = parseInt(time.split(':')[0]);
-    const dayOfWeek = new Date(date).getDay();
-    return hour === 12 || dayOfWeek === 0 || dayOfWeek === 6;
-  };
+  const timeSlotData = generateTimeSlots(startDateString || '', endDateString || '');
 
   const toggleSlot = (slotIso: string) => {
     setSelectedSlots((prev) => {

--- a/apps/web/src/pages/ResponsePage.tsx
+++ b/apps/web/src/pages/ResponsePage.tsx
@@ -15,11 +15,7 @@ import {
   CircularProgress,
 } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-
-interface TimeSlotData {
-  date: string;
-  slots: string[];
-}
+import { generateTimeSlots, isBlockedSlot } from '../utils/timeSlot';
 
 export default function ResponsePage() {
   const { id } = useParams();
@@ -69,54 +65,7 @@ export default function ResponsePage() {
   const startDateString = dashboardData?.startDate;
   const endDateString = dashboardData?.endDate;
 
-  const timeSlotData = useMemo<TimeSlotData[]>(() => {
-    if (!startDateString || !endDateString) return [];
-
-    const startDate = new Date(startDateString);
-    const endDate = new Date(endDateString);
-
-    if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
-      return [];
-    }
-
-    const dates: string[] = [];
-    const current = new Date(startDate);
-    current.setHours(0, 0, 0, 0);
-
-    const end = new Date(endDate);
-    end.setHours(0, 0, 0, 0);
-
-    while (current <= end) {
-      const dayOfWeek = current.getDay();
-      if (dayOfWeek !== 0 && dayOfWeek !== 6) {
-        dates.push(current.toISOString());
-      }
-      current.setDate(current.getDate() + 1);
-    }
-
-    return dates.map((date) => {
-      const slots: string[] = [];
-
-      for (let hour = 9; hour < 18; hour++) {
-        if (hour === 12) continue;
-
-        for (let minute = 0; minute < 60; minute += 30) {
-          const timeStr = `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
-          const slotDate = new Date(date);
-          slotDate.setHours(hour, minute, 0, 0);
-          slots.push(`${slotDate.toISOString()}|${timeStr}`);
-        }
-      }
-
-      return { date, slots };
-    });
-  }, [startDateString, endDateString]);
-
-  const isBlockedSlot = (date: string, time: string): boolean => {
-    const hour = parseInt(time.split(':')[0]);
-    const dayOfWeek = new Date(date).getDay();
-    return hour === 12 || dayOfWeek === 0 || dayOfWeek === 6;
-  };
+  const timeSlotData = useMemo(() => generateTimeSlots(startDateString || '', endDateString || ''), [startDateString, endDateString]);
 
   const isOrganizerUnavailable = (slotIso: string): boolean => {
     if (!dashboardData?.organizerAvailableSlots) return false;

--- a/apps/web/src/pages/ResponsePage.tsx
+++ b/apps/web/src/pages/ResponsePage.tsx
@@ -51,6 +51,7 @@ export default function ResponsePage() {
         participants: Array<{ userId: string; name: string; responded: boolean }>;
         startDate: string;
         endDate: string;
+        organizerAvailableSlots?: string[];
       }>;
     },
   });
@@ -115,6 +116,11 @@ export default function ResponsePage() {
     const hour = parseInt(time.split(':')[0]);
     const dayOfWeek = new Date(date).getDay();
     return hour === 12 || dayOfWeek === 0 || dayOfWeek === 6;
+  };
+
+  const isOrganizerUnavailable = (slotIso: string): boolean => {
+    if (!dashboardData?.organizerAvailableSlots) return false;
+    return !dashboardData.organizerAvailableSlots.includes(slotIso);
   };
 
   const getSlotStatus = (slotIso: string) => {
@@ -400,7 +406,9 @@ export default function ResponsePage() {
                 const status = getSlotStatus(slotIso);
                 const isAvailable = status === 'available';
                 const isUnavailable = status === 'unavailable';
-                const isBlocked = isBlockedSlot(dateSlot.date, time);
+                const isHolidayBlocked = isBlockedSlot(dateSlot.date, time);
+                const isOrganizerBlocked = isOrganizerUnavailable(slotIso);
+                const isBlocked = isHolidayBlocked || isOrganizerBlocked;
                 const isUnselected = status === 'none';
 
                 return (
@@ -415,17 +423,22 @@ export default function ResponsePage() {
                         ? '3px solid #4caf50'
                         : isUnavailable
                           ? '3px solid #f44336'
-                          : '2px solid #e0e0e0',
+                          : isOrganizerBlocked
+                            ? '2px dashed #ff9800'
+                            : '2px solid #e0e0e0',
                       borderRadius: '8px',
                       backgroundColor: isAvailable
                         ? '#e8f5e9'
                         : isUnavailable
                           ? '#ffebee'
-                          : 'white',
-                      color: isAvailable ? '#2e7d32' : isUnavailable ? '#c62828' : '#333',
+                          : isOrganizerBlocked
+                            ? '#fff3e0'
+                            : 'white',
+                      color: isAvailable ? '#2e7d32' : isUnavailable ? '#c62828' : isOrganizerBlocked ? '#e65100' : '#333',
                       fontWeight: 'bold',
-                      opacity: isBlocked ? 0.4 : 1,
+                      opacity: isHolidayBlocked ? 0.4 : isOrganizerBlocked ? 0.6 : 1,
                       fontSize: '0.875rem',
+                      position: 'relative',
                     }}
                   >
                     {time}

--- a/apps/web/src/utils/timeSlot.ts
+++ b/apps/web/src/utils/timeSlot.ts
@@ -1,0 +1,55 @@
+
+
+export interface TimeSlotData {
+  date: string;
+  slots: string[];
+}
+
+export const generateTimeSlots = (startDateString: string, endDateString: string): TimeSlotData[] => {
+  if (!startDateString || !endDateString) return [];
+
+  const startDate = new Date(startDateString);
+  const endDate = new Date(endDateString);
+
+  if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+    return [];
+  }
+
+  const dates: string[] = [];
+  const current = new Date(startDate);
+  current.setHours(0, 0, 0, 0);
+
+  const end = new Date(endDate);
+  end.setHours(0, 0, 0, 0);
+
+  while (current <= end) {
+    const dayOfWeek = current.getDay();
+    if (dayOfWeek !== 0 && dayOfWeek !== 6) {
+      dates.push(current.toISOString());
+    }
+    current.setDate(current.getDate() + 1);
+  }
+
+  return dates.map((date) => {
+    const slots: string[] = [];
+
+    for (let hour = 9; hour < 18; hour++) {
+      if (hour === 12) continue;
+
+      for (let minute = 0; minute < 60; minute += 30) {
+        const timeStr = `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+        const slotDate = new Date(date);
+        slotDate.setHours(hour, minute, 0, 0);
+        slots.push(`${slotDate.toISOString()}|${timeStr}`);
+      }
+    }
+
+    return { date, slots };
+  });
+};
+
+export const isBlockedSlot = (date: string, time: string): boolean => {
+  const hour = parseInt(time.split(':')[0]);
+  const dayOfWeek = new Date(date).getDay();
+  return hour === 12 || dayOfWeek === 0 || dayOfWeek === 6;
+};

--- a/packages/shared/src/dto.ts
+++ b/packages/shared/src/dto.ts
@@ -21,6 +21,7 @@ export interface CreateMeetingRequestDto {
   endDate: string;
   durationMinutes: number;
   location?: string;
+  organizerAvailableSlots?: string[];
 }
 
 export interface CreateMeetingResponseDto {
@@ -56,6 +57,7 @@ export interface DashboardDto {
     date: string;
     times: string[];
   }>;
+  organizerAvailableSlots?: string[];
   createdAt: string;
   startDate: string;
   endDate: string;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,14 +1,18 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 import path from 'path';
 
 export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'node',
-  },
+  plugins: [react()],
   resolve: {
     alias: {
       '@shared': path.resolve(__dirname, './packages/shared/src'),
     },
   },
+  test: {
+    globals: true,
+    environment: 'node',
+    setupFiles: './apps/web/src/test/setup.ts',
+  },
 });
+

--- a/work-history/2026-01-14-work-plan.md
+++ b/work-history/2026-01-14-work-plan.md
@@ -1,0 +1,114 @@
+# 2026-01-14 작업 계획
+
+## 오늘 완료된 작업
+
+### ✅ 주최자 시간 선택 기능 구현
+- **PR**: #12 (https://github.com/Crong-Gabia/BookingTime/pull/12)
+- **브랜치**: `feature/organizer-time-selection`
+- **구현 내용**:
+  - 주최자가 회의 생성 시 자신의 가능한 시간 먼저 선택
+  - 참여자는 주최자가 선택한 시간만 응답 가능
+  - 주최자 불가 시간 orange dashed border로 표시 및 disabled 처리
+
+## 오늘 해야 할 작업 (TODO)
+
+### 1순위: 빌드/테스트 환경 안정화 ⚠️ 긴급
+
+#### 1.1 TypeScript LSP 데코레이터 에러 수정
+- **파일**: `apps/api/src/modules/meeting/meeting.service.ts`, `meeting.controller.ts`, `health.controller.ts`
+- **문제**: `Decorators are not valid here` 오류
+- **해결**: tsconfig 설정 확인 및 데코레이터 사용 방식 수정
+
+#### 1.2 테스트 파일 vi 네임스페이스 오류 수정
+- **파일**: `apps/api/src/modules/meeting/health.test.ts`, `meeting.test.ts`
+- **문제**: `Cannot find namespace 'vi'` 오류
+- **해결**: Vitest 타입 설정 추가 (`vitest/globals`)
+
+#### 1.3 DashboardPage 타입 에러 수정
+- **파일**: `apps/web/src/pages/DashboardPage.tsx`
+- **문제**: 파라미터 `any` 타입 사용, 컴포넌트 props 미스매치
+- **해결**: 타입 명시적 선언, props 타입 확인
+
+#### 1.4 HomePage 미사용 변수 제거
+- **파일**: `apps/web/src/pages/HomePage.tsx`
+- **문제**: `Meeting`, `meetingsLoading` 선언 후 미사용
+- **해결**: 미사용 변수 삭제
+
+#### 1.5 DB/도커 환경 세팅 확인
+- **상태**: ✅ 도커 컨테이너 시작됨 (postgres, redis)
+- **확인 필요**:
+  - DB 마이그레이션 실행
+  - 개발 서버 정상 시작 확인
+  - API 엔드포인트 테스트
+
+### 2순위: 기능 개선
+
+#### 2.1 External Adapters 실제 구현 (Issue #11)
+- **RoomAdapter**: 회의실 예약 시스템 API 연동
+- **HolidayAdapter**: 공휴일 API 연동
+- **HRAdapter**: 사내 HR/근태 시스템 API 연동
+
+#### 2.2 응답 기한 강제 종료 기능
+- 기획: 매일 특정 시간에 자동 종료
+- 현재: 주최자가 수동으로 [확정] 버튼 누를 때만 종료
+- 필요: 타이머 기능 또는 기한 설정 UI 추가
+
+#### 2.3 알림 발송 연동 (메신저 봇)
+- 현재: `sendReminder()` API 존재하지만 실제 발송 없음
+- 필요: Slack/Teams/KakaoWorkplace 등 연동
+
+### 3순위: 기획서 기준 MVP 완성
+
+#### 3.1 미응답자 처리 로직
+- 기획: 시스템에서 강제 제외하지 않음
+- 현재: 미응답자도 공통 슬롯에 포함됨
+- 필요: 미응답자를 고려한 공통 슬롯 계산 또는 "제외하고 진행" 기능
+
+#### 3.2 회의실 예약 시스템 실제 연동
+- 기획: RoomAPI를 통해 회의실 예약 + 캘린더 등록
+- 현재: 단순 체크만 수행
+- 필요: 실제 예약 API 호출 + 캘린더 등록
+
+### 4순위: Phase 2 고도화 (장기 계획)
+
+#### 4.1 지능형 추천 (AI)
+- 참석자들이 주로 선호하는 시간대 추천
+- 회의실 동선 고려한 추천
+
+#### 4.2 LLM 기반 자연어 생성
+- "다음 주 김팀장님이랑 면접 잡아줘" 입력하면 폼 자동 채우기
+
+#### 4.3 회의실 자동 배정
+- 참석 인원수와 회의실 정원 비교하여 최적 회의실 자동 선택
+
+#### 4.4 외부 캘린더 연동
+- Google/네이버 캘린더 API 연동
+- 사외 일정까지 고려한 필터링
+
+---
+
+## 작업 우선순위 요약
+
+1. **즉시 해결 (오늘 목표)**
+   - ✅ 도커/DB 환경 세팅
+   - ⏳ TypeScript LSP 에러 수정
+   - ⏳ 테스트 vi 네임스페이스 오류 수정
+   - ⏳ DashboardPage 타입 에러 수정
+   - ⏳ 빌드 성공 확인
+
+2. **1순위 (이번 주)**
+   - Issue #11: External Adapters 실제 구현
+   - 응답 기한 강제 종료 기능
+   - 알림 발송 연동
+
+3. **2순위 (다음 주 이후)**
+   - MVP 완성 (미응답자 처리, 회의실 예약 연동)
+   - Phase 2 고도화 기능
+
+---
+
+## 참고
+
+- 기획서: `work-history/product-spec/plan.md`
+- 개발 가이드: `guidelines/README.md`
+- GitHub Issues: https://github.com/Crong-Gabia/BookingTime/issues


### PR DESCRIPTION
## 요약

주최자가 회의를 생성할 때 자신이 가능한 시간을 먼저 선택하고, 참여자는 주최자가 선택한 시간 내에서만 응답할 수 있도록 하는 기능을 구현했습니다.

## 변경 사항

### Backend
- **CreateMeetingRequestDto**: `organizerAvailableSlots?: string[]` 필드 추가
- **DashboardDto**: `organizerAvailableSlots?: string[]` 필드 추가
- **MeetingService.createRequest()**: 주최자 시간 슬롯 처리 로직 추가
  - `updateOrganizerAvailability()` 메서드로 선택되지 않은 슬롯을 UNAVAILABLE로 변경
- **MeetingService.getDashboard()**: 주최자 가능 시간 슬롯 반환
- **MeetingService.updateOrganizerAvailability()**: 새로운 프라이빗 메서드
  - 선택되지 않은 주최자 슬롯을 UNAVAILABLE로 대량 업데이트
- **meeting.service.spec.ts**: 새로운 기능에 대한 단위 테스트 추가

### Frontend
- **OrganizerSlotSelectionPage.tsx**: 주최자 시간 선택 페이지 (완전히 새로 구현)
  - CreatePage에서 전달받은 회의 정보 표시
  - 시간 슬롯 선택 UI (기존 ResponsePage와 유사한 UX)
  - "전체 선택" / "전체 해제" 버튼
  - 선택된 슬롯 수량 표시
- **CreatePage.tsx**: 회의 생성 플로우 변경
  - "회의 요청 생성" 버튼 → "다음: 시간 선택" 버튼
  - 시간 선택 페이지로 네비게이션 (React Router state로 데이터 전달)
  - 불필요한 `isSubmitting` 상태 제거
- **ResponsePage.tsx**: 주최자 불가 시간 시각적 구분
  - `isOrganizerUnavailable()` 함수로 주최자 불가 시간 체크
  - Holiday blocked (opacity 0.4) vs Organizer blocked (opacity 0.6, orange dashed border)
- **App.tsx**: `/requests/new/slots` 라우팅 추가

## 사용자 경험

1. **주최자**:
   - 회의 기본 정보 입력 (제목, 참여자, 날짜, 기간)
   - "다음: 시간 선택" 버튼 클릭
   - 시간 선택 페이지에서 가능한 시간을 모두 선택
   - "회의 생성 (N개 선택)" 버튼으로 회의 생성 완료

2. **참여자**:
   - 기존과 동일하게 응답 페이지 접속
   - 주최자가 불가한 시간은 **orange dashed border**로 표시되고 **disabled**
   - 주최자가 가능한 시간만 선택 가능

## 기술 세부사항

### 데이터 모델
- 기존 `TimeSlot.status` enum 활용 (AVAILABLE, UNAVAILABLE, BLOCKED)
- 주최자 슬롯은 `participantId: NULL`으로 저장
- `updateOrganizerAvailability()`가 선택되지 않은 슬롯만 UNAVAILABLE로 변경

### UI 차별화
- **Holiday blocked**: `opacity: 0.4`, gray
- **Organizer blocked**: `opacity: 0.6`, `#fff3e0` background, orange dashed border (`#ff9800`), `#e65100` text
- 참여자가 명확히 구분 가능

## 빌드 상태
- ✅ API 빌드 성공
- ✅ Shared 패키지 빌드 성공
- ✅ Web 앱 새 코드 컴파일 성공

## 테스트
- 백엔드 단위 테스트 추가 (meeting.service.spec.ts)
  - 주최자 시간 슬롯 업데이트 테스트
  - 시간 없으면 모든 슬롯 유지 테스트
  - 대시보드에 주최자 시간 반환 테스트