### PR TITLE
fix: response submit parsing and deadline checks

### DIFF
--- a/apps/api/src/modules/meeting/meeting.service.ts
+++ b/apps/api/src/modules/meeting/meeting.service.ts
@@ -45,7 +45,6 @@ export class MeetingService {
         durationMinutes: dto.durationMinutes,
         location: dto.location,
         status: MeetingStatus.OPEN,
-        // @ts-ignore - responseDeadlineAt field exists in Prisma schema but type definition is not syncing
         responseDeadlineAt: responseDeadlineAt ?? undefined,
         participants: {
           create: dto.participantIds.map((userId) => ({
@@ -71,7 +70,6 @@ export class MeetingService {
       endDate: request.endDate.toISOString(),
       durationMinutes: request.durationMinutes,
       createdAt: request.createdAt.toISOString(),
-      // @ts-ignore - responseDeadlineAt field exists in Prisma schema but type definition is not syncing
       responseDeadlineAt: request.responseDeadlineAt?.toISOString() ?? null,
     };
   }
@@ -272,10 +270,9 @@ export class MeetingService {
       throw new BadRequestException(ERROR_CODES.REQUEST_CLOSED, 'Request is closed');
     }
 
-    // TODO: Re-enable deadline check once Prisma type definitions sync properly
-    // if (request.responseDeadlineAt && new Date() >= request.responseDeadlineAt) {
-    //   throw new BadRequestException(ERROR_CODES.REQUEST_CLOSED, 'Request is closed');
-    // }
+    if (request.responseDeadlineAt && new Date() >= request.responseDeadlineAt) {
+      throw new BadRequestException(ERROR_CODES.REQUEST_CLOSED, 'Request is closed');
+    }
   }
 
   private async generateTimeSlots(requestId: string, startDate: Date, endDate: Date) {

--- a/apps/web/src/pages/ResponsePage.tsx
+++ b/apps/web/src/pages/ResponsePage.tsx
@@ -27,22 +27,51 @@ export default function ResponsePage() {
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  const parseJsonBody = (value: string) => {
+    if (!value) return null;
+    try {
+      return JSON.parse(value) as { message?: string } | null;
+    } catch (error) {
+      return null;
+    }
+  };
+
+  const readResponseBody = async (response: Response) => {
+    if (typeof response.text === 'function') {
+      const text = await response.text();
+      return { text, data: parseJsonBody(text) };
+    }
+
+    if (typeof response.json === 'function') {
+      const data = (await response.json()) as { message?: string } | null;
+      return { text: '', data };
+    }
+
+    return { text: '', data: null };
+  };
+
   const { data: dashboardData, isLoading: dashboardLoading, error: dashboardError } = useQuery({
     queryKey: ['meeting-dashboard', id],
     enabled: Boolean(id),
     queryFn: async () => {
       const response = await fetch(`/api/meetings/${id}/dashboard`);
+      const { text, data } = await readResponseBody(response);
+
       if (!response.ok) {
         let message = 'Failed to load dashboard';
-        try {
-          const errorBody = await response.json();
-          if (errorBody?.message && typeof errorBody.message === 'string') {
-            message = errorBody.message;
-          }
-        } catch {}
+        if (data && typeof data.message === 'string') {
+          message = data.message;
+        } else if (text) {
+          message = text;
+        }
         throw new Error(message);
       }
-      return response.json() as Promise<{
+
+      if (!data) {
+        throw new Error('Failed to load dashboard');
+      }
+
+      return data as {
         requestId: string;
         title: string;
         status: string;
@@ -50,7 +79,7 @@ export default function ResponsePage() {
         startDate: string;
         endDate: string;
         organizerAvailableSlots?: string[];
-      }>;
+      };
     },
   });
 
@@ -166,17 +195,19 @@ export default function ResponsePage() {
         }),
       });
 
-      const responseBody = await response.text();
-      const data = responseBody ? JSON.parse(responseBody) : null;
+      const { text, data } = await readResponseBody(response);
 
       if (!response.ok) {
         if (data && typeof data.message === 'string') {
           throw new Error(data.message);
         }
+        if (text) {
+          throw new Error(text);
+        }
         throw new Error('제출 실패');
       }
 
-      return data;
+      return data ?? text ?? null;
     },
     onSuccess: () => {
       setIsSubmitted(true);

--- a/apps/web/src/pages/ResponsePage.tsx
+++ b/apps/web/src/pages/ResponsePage.tsx
@@ -166,18 +166,17 @@ export default function ResponsePage() {
         }),
       });
 
+      const responseBody = await response.text();
+      const data = responseBody ? JSON.parse(responseBody) : null;
+
       if (!response.ok) {
-        let message = 'Failed to submit';
-        try {
-          const errorBody = await response.json();
-          if (errorBody?.message && typeof errorBody.message === 'string') {
-            message = errorBody.message;
-          }
-        } catch {}
-        throw new Error(message);
+        if (data && typeof data.message === 'string') {
+          throw new Error(data.message);
+        }
+        throw new Error('제출 실패');
       }
 
-      return response.json();
+      return data;
     },
     onSuccess: () => {
       setIsSubmitted(true);


### PR DESCRIPTION
## Summary
- Avoid JSON parsing errors when the respond endpoint returns an empty body
- Restore response deadline checks and remove temporary type suppressions

## Testing
- `pnpm --filter api build`
- `pnpm --filter web test --run src/pages/ResponsePage.test.tsx`