### PR TITLE
feat: 회식 meetingType/mealTime 풀스택 지원

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -8,24 +8,26 @@ datasource db {
 }
 
 model MeetingRequest {
-  id                String           @id @default(cuid())
-  title             String
-  organizerId       String
-  status            MeetingStatus    @default(DRAFT)
-  startDate         DateTime
-  endDate           DateTime
-  durationMinutes   Int
-  location          String?
-  version           Int              @default(1)
-  closedAt          DateTime?
+  id                 String           @id @default(cuid())
+  title              String
+  organizerId        String
+  status             MeetingStatus    @default(DRAFT)
+  startDate          DateTime
+  endDate            DateTime
+  durationMinutes    Int
+  location           String?
+  meetingType        MeetingType      @default(GENERAL)
+  mealTime           MealTime?
+  version            Int              @default(1)
+  closedAt           DateTime?
   responseDeadlineAt DateTime?
-  createdAt         DateTime         @default(now())
-  updatedAt         DateTime         @updatedAt
-  deletedAt         DateTime?
+  createdAt          DateTime         @default(now())
+  updatedAt          DateTime         @updatedAt
+  deletedAt          DateTime?
 
-  participants      Participant[]
-  confirmedMeeting  ConfirmedMeeting?
-  timeSlots         TimeSlot[]
+  participants       Participant[]
+  confirmedMeeting   ConfirmedMeeting?
+  timeSlots          TimeSlot[]
 
   @@index([status])
   @@index([createdAt])
@@ -96,4 +98,14 @@ enum SlotStatus {
   AVAILABLE
   UNAVAILABLE
   BLOCKED
+}
+
+enum MeetingType {
+  GENERAL
+  COMPANY_DINNER
+}
+
+enum MealTime {
+  LUNCH
+  DINNER
 }

--- a/apps/api/src/modules/meeting/adapters/holiday.adapter.ts
+++ b/apps/api/src/modules/meeting/adapters/holiday.adapter.ts
@@ -2,6 +2,7 @@ import { IHolidayAdapter } from './interfaces';
 
 export class HolidayAdapter implements IHolidayAdapter {
   async isHoliday(_date: Date): Promise<boolean> {
+    void _date;
     return false;
   }
 }

--- a/apps/api/src/modules/meeting/adapters/hr.adapter.ts
+++ b/apps/api/src/modules/meeting/adapters/hr.adapter.ts
@@ -2,6 +2,7 @@ import { IHrAdapter } from './interfaces';
 
 export class HrAdapter implements IHrAdapter {
   getUserName(_userId: string): string {
+    void _userId;
     return '사용자';
   }
 }

--- a/apps/api/src/modules/meeting/adapters/room.adapter.ts
+++ b/apps/api/src/modules/meeting/adapters/room.adapter.ts
@@ -2,6 +2,8 @@ import { IRoomAdapter } from './interfaces';
 
 export class RoomAdapter implements IRoomAdapter {
   async isAvailable(_timeSlot: string, _location?: string): Promise<boolean> {
+    void _timeSlot;
+    void _location;
     return true;
   }
 }

--- a/apps/api/src/modules/meeting/meeting.controller.ts
+++ b/apps/api/src/modules/meeting/meeting.controller.ts
@@ -15,7 +15,7 @@ export class MeetingController {
   constructor(private readonly meetingService: MeetingService) {}
 
   @Get()
-  async getAll(): Promise<{ meetings: Array<{ id: string; title: string; status: string; responseRate: number; createdAt: string }> }> {
+  async getAll(): Promise<{ meetings: Array<{ id: string; title: string; status: string; responseRate: number; createdAt: string; meetingType: string; mealTime?: string | null }> }> {
     return this.meetingService.getAllMeetings();
   }
 

--- a/apps/api/src/modules/meeting/meeting.service.spec.ts
+++ b/apps/api/src/modules/meeting/meeting.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { MeetingService } from './meeting.service';
 import { PrismaService } from '../../common/prisma/prisma.service';
 import { IRoomAdapter, IHolidayAdapter, IHrAdapter } from './adapters/interfaces';
-import { CreateMeetingRequestDto, MeetingRequestStatus } from 'shared';
+import { CreateMeetingRequestDto } from 'shared';
 
 describe('MeetingService', () => {
   let service: MeetingService;
@@ -260,6 +260,7 @@ class HolidayAdapterMock implements IHolidayAdapter {
 
 class HrAdapterMock implements IHrAdapter {
   getUserName(_userId: string): string {
+    void _userId;
     return 'Test User';
   }
 }

--- a/apps/api/src/modules/meeting/meeting.service.ts
+++ b/apps/api/src/modules/meeting/meeting.service.ts
@@ -10,6 +10,8 @@ import {
   RemindResponseDto,
   ERROR_CODES,
   MeetingRequestStatus,
+  MeetingType,
+  MealTime,
 } from 'shared';
 import { MeetingStatus, SlotStatus } from '@prisma/client';
 import { IRoomAdapter, IHolidayAdapter, IHrAdapter } from './adapters/interfaces';
@@ -36,6 +38,17 @@ export class MeetingService {
       throw new BadRequestException('Invalid response deadline');
     }
 
+    const meetingType = dto.meetingType ?? MeetingType.GENERAL;
+    const mealTime = dto.mealTime ?? null;
+
+    if (meetingType === MeetingType.COMPANY_DINNER && !mealTime) {
+      throw new BadRequestException('mealTime is required for company dinner');
+    }
+
+    if (meetingType !== MeetingType.COMPANY_DINNER && mealTime) {
+      throw new BadRequestException('mealTime is only allowed for company dinner');
+    }
+
     const request = await this.prisma.meetingRequest.create({
       data: {
         title: dto.title,
@@ -44,6 +57,8 @@ export class MeetingService {
         endDate,
         durationMinutes: dto.durationMinutes,
         location: dto.location,
+        meetingType,
+        mealTime,
         status: MeetingStatus.OPEN,
         responseDeadlineAt: responseDeadlineAt ?? undefined,
         participants: {
@@ -52,7 +67,7 @@ export class MeetingService {
             name: this.hrAdapter.getUserName(userId),
           })),
         },
-      },
+      } as unknown as Parameters<typeof this.prisma.meetingRequest.create>[0]['data'],
     });
 
     await this.generateTimeSlots(request.id, request.startDate, request.endDate);
@@ -71,6 +86,8 @@ export class MeetingService {
       durationMinutes: request.durationMinutes,
       createdAt: request.createdAt.toISOString(),
       responseDeadlineAt: request.responseDeadlineAt?.toISOString() ?? null,
+      meetingType,
+      mealTime,
     };
   }
 
@@ -111,10 +128,15 @@ export class MeetingService {
       select: { slotDate: true },
     });
 
+    const meetingTypeValue = (request as { meetingType?: MeetingType }).meetingType ?? MeetingType.GENERAL;
+    const mealTimeValue = (request as { mealTime?: MealTime | null }).mealTime ?? null;
+
     return {
       requestId: request.id,
       title: request.title,
       status: request.status as MeetingRequestStatus,
+      meetingType: meetingTypeValue,
+      mealTime: mealTimeValue,
       participants: request.participants.map((p) => ({
         userId: p.userId,
         name: p.name,
@@ -391,7 +413,7 @@ export class MeetingService {
     return `${requestId}-${participantId}-${slotDate}`;
   }
 
-  async getAllMeetings(): Promise<{ meetings: Array<{ id: string; title: string; status: string; responseRate: number; createdAt: string }> }> {
+  async getAllMeetings(): Promise<{ meetings: Array<{ id: string; title: string; status: string; responseRate: number; createdAt: string; meetingType: MeetingType; mealTime?: MealTime | null }> }> {
     if (!process.env.DATABASE_URL) {
       return {
         meetings: [
@@ -401,6 +423,8 @@ export class MeetingService {
             status: MeetingStatus.OPEN,
             responseRate: 0,
             createdAt: new Date().toISOString(),
+            meetingType: MeetingType.GENERAL,
+            mealTime: null,
           },
         ],
       };
@@ -427,6 +451,8 @@ export class MeetingService {
           status: req.status,
           responseRate,
           createdAt: req.createdAt.toISOString(),
+          meetingType: (req as { meetingType?: MeetingType }).meetingType ?? MeetingType.GENERAL,
+          mealTime: (req as { mealTime?: MealTime | null }).mealTime ?? null,
         };
       });
 
@@ -441,6 +467,8 @@ export class MeetingService {
             status: MeetingStatus.OPEN,
             responseRate: 0,
             createdAt: new Date().toISOString(),
+            meetingType: MeetingType.GENERAL,
+            mealTime: null,
           },
         ],
       };

--- a/apps/api/src/modules/meeting/meeting.service.ts
+++ b/apps/api/src/modules/meeting/meeting.service.ts
@@ -13,7 +13,7 @@ import {
   MeetingType,
   MealTime,
 } from 'shared';
-import { MeetingStatus, SlotStatus } from '@prisma/client';
+import { MeetingStatus, SlotStatus, MeetingType as PrismaMeetingType, MealTime as PrismaMealTime } from '@prisma/client';
 import { IRoomAdapter, IHolidayAdapter, IHrAdapter } from './adapters/interfaces';
 
 @Injectable()
@@ -49,6 +49,9 @@ export class MeetingService {
       throw new BadRequestException('mealTime is only allowed for company dinner');
     }
 
+    const prismaMeetingType = this.toPrismaMeetingType(meetingType);
+    const prismaMealTime = this.toPrismaMealTime(mealTime);
+
     const request = await this.prisma.meetingRequest.create({
       data: {
         title: dto.title,
@@ -57,8 +60,8 @@ export class MeetingService {
         endDate,
         durationMinutes: dto.durationMinutes,
         location: dto.location,
-        meetingType,
-        mealTime,
+        meetingType: prismaMeetingType,
+        mealTime: prismaMealTime,
         status: MeetingStatus.OPEN,
         responseDeadlineAt: responseDeadlineAt ?? undefined,
         participants: {
@@ -67,7 +70,7 @@ export class MeetingService {
             name: this.hrAdapter.getUserName(userId),
           })),
         },
-      } as unknown as Parameters<typeof this.prisma.meetingRequest.create>[0]['data'],
+      },
     });
 
     await this.generateTimeSlots(request.id, request.startDate, request.endDate);
@@ -86,8 +89,8 @@ export class MeetingService {
       durationMinutes: request.durationMinutes,
       createdAt: request.createdAt.toISOString(),
       responseDeadlineAt: request.responseDeadlineAt?.toISOString() ?? null,
-      meetingType,
-      mealTime,
+      meetingType: this.toSharedMeetingType(request.meetingType),
+      mealTime: this.toSharedMealTime(request.mealTime),
     };
   }
 
@@ -128,8 +131,8 @@ export class MeetingService {
       select: { slotDate: true },
     });
 
-    const meetingTypeValue = (request as { meetingType?: MeetingType }).meetingType ?? MeetingType.GENERAL;
-    const mealTimeValue = (request as { mealTime?: MealTime | null }).mealTime ?? null;
+    const meetingTypeValue = this.toSharedMeetingType(request.meetingType);
+    const mealTimeValue = this.toSharedMealTime(request.mealTime);
 
     return {
       requestId: request.id,
@@ -413,6 +416,24 @@ export class MeetingService {
     return `${requestId}-${participantId}-${slotDate}`;
   }
 
+  private toPrismaMeetingType(meetingType: MeetingType): PrismaMeetingType {
+    return meetingType === MeetingType.COMPANY_DINNER ? PrismaMeetingType.COMPANY_DINNER : PrismaMeetingType.GENERAL;
+  }
+
+  private toPrismaMealTime(mealTime: MealTime | null): PrismaMealTime | null {
+    if (!mealTime) return null;
+    return mealTime === MealTime.LUNCH ? PrismaMealTime.LUNCH : PrismaMealTime.DINNER;
+  }
+
+  private toSharedMeetingType(meetingType: PrismaMeetingType): MeetingType {
+    return meetingType === PrismaMeetingType.COMPANY_DINNER ? MeetingType.COMPANY_DINNER : MeetingType.GENERAL;
+  }
+
+  private toSharedMealTime(mealTime: PrismaMealTime | null): MealTime | null {
+    if (!mealTime) return null;
+    return mealTime === PrismaMealTime.LUNCH ? MealTime.LUNCH : MealTime.DINNER;
+  }
+
   async getAllMeetings(): Promise<{ meetings: Array<{ id: string; title: string; status: string; responseRate: number; createdAt: string; meetingType: MeetingType; mealTime?: MealTime | null }> }> {
     if (!process.env.DATABASE_URL) {
       return {
@@ -451,8 +472,8 @@ export class MeetingService {
           status: req.status,
           responseRate,
           createdAt: req.createdAt.toISOString(),
-          meetingType: (req as { meetingType?: MeetingType }).meetingType ?? MeetingType.GENERAL,
-          mealTime: (req as { mealTime?: MealTime | null }).mealTime ?? null,
+          meetingType: this.toSharedMeetingType(req.meetingType),
+          mealTime: this.toSharedMealTime(req.mealTime),
         };
       });
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>WhatTime - 회의 예약 시스템</title>
+    <title>우리지금만나 - 만남 예약 시스템</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -36,6 +36,8 @@ export interface Meeting {
   status: string;
   responseRate: number;
   createdAt: string;
+  meetingType?: 'GENERAL' | 'COMPANY_DINNER';
+  mealTime?: 'LUNCH' | 'DINNER' | null;
 }
 
 export async function getAllMeetings(): Promise<{ meetings: Meeting[] }> {

--- a/apps/web/src/api/meeting.ts
+++ b/apps/web/src/api/meeting.ts
@@ -22,6 +22,10 @@ export async function createMeeting(payload: {
   endDate: string;
   participantIds: string[];
   organizerId: string;
+  meetingType?: 'GENERAL' | 'COMPANY_DINNER';
+  mealTime?: 'LUNCH' | 'DINNER' | null;
+  organizerAvailableSlots?: string[];
+  responseDeadlineAt?: string | null;
 }) {
   const response = await fetch('/api/meetings', {
     method: 'POST',
@@ -87,6 +91,8 @@ export type DashboardData = {
   title: string;
   description?: string;
   status: string;
+  meetingType: 'GENERAL' | 'COMPANY_DINNER';
+  mealTime?: 'LUNCH' | 'DINNER' | null;
   participants: Array<{
     userId: string;
     name: string;
@@ -100,6 +106,8 @@ export type DashboardData = {
   startDate: string;
   endDate: string;
   durationMinutes: number;
+  organizerAvailableSlots?: string[];
+  responseDeadlineAt?: string | null;
 };
 
 export type CreateMeetingRequestDto = {
@@ -110,6 +118,10 @@ export type CreateMeetingRequestDto = {
   endDate: string;
   participantIds: string[];
   organizerId: string;
+  meetingType?: 'GENERAL' | 'COMPANY_DINNER';
+  mealTime?: 'LUNCH' | 'DINNER' | null;
+  organizerAvailableSlots?: string[];
+  responseDeadlineAt?: string | null;
 };
 
 export type SubmitResponseDto = {

--- a/apps/web/src/components/empty-state.test.tsx
+++ b/apps/web/src/components/empty-state.test.tsx
@@ -64,13 +64,13 @@ describe('EmptyState', () => {
     const action = <button type="button">일정 추가</button>;
     render(
       <EmptyState
-        message="아직 회의 일정이 없습니다"
+        message="아직 만남 일정이 없습니다"
         action={action}
       />,
     );
 
     const icon = document.querySelector('svg');
-    const message = screen.getByText('아직 회의 일정이 없습니다');
+    const message = screen.getByText('아직 만남 일정이 없습니다');
     const button = screen.getByRole('button', { name: '일정 추가' });
 
     expect(icon).toBeInTheDocument();

--- a/apps/web/src/components/meeting-card.tsx
+++ b/apps/web/src/components/meeting-card.tsx
@@ -9,6 +9,8 @@ interface MeetingCardProps {
   responseRate: number;
   totalParticipants: number;
   respondedParticipants: number;
+  meetingType?: 'GENERAL' | 'COMPANY_DINNER';
+  mealTime?: 'LUNCH' | 'DINNER' | null;
   onClick: () => void;
 }
 
@@ -18,6 +20,8 @@ export default function MeetingCard({
   responseRate,
   totalParticipants,
   respondedParticipants,
+  meetingType,
+  mealTime,
   onClick,
 }: MeetingCardProps) {
   return (
@@ -39,6 +43,18 @@ export default function MeetingCard({
         <Typography variant="body2" color="text.secondary" gutterBottom>
           {date}
         </Typography>
+        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mt: 1 }}>
+          {meetingType && (
+            <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
+              {meetingType === 'COMPANY_DINNER' ? '회식' : '일반'}
+            </Typography>
+          )}
+          {mealTime && (
+            <Typography variant="caption" color="text.secondary">
+              {mealTime === 'LUNCH' ? '점심 12~13시' : '저녁 18~20시'}
+            </Typography>
+          )}
+        </Box>
         <Box sx={{ mt: 2 }}>
           <ProgressBar
             value={responseRate}

--- a/apps/web/src/components/room-selector.test.tsx
+++ b/apps/web/src/components/room-selector.test.tsx
@@ -5,12 +5,12 @@ import RoomSelector from './room-selector';
 
 describe('RoomSelector', () => {
   const mockRooms = [
-    { id: 'room-1', name: '회의실 A', capacity: 10 },
-    { id: 'room-2', name: '회의실 B', capacity: 20 },
-    { id: 'room-3', name: '회의실 C', capacity: 8 },
+    { id: 'room-1', name: '공간 A', capacity: 10 },
+    { id: 'room-2', name: '공간 B', capacity: 20 },
+    { id: 'room-3', name: '공간 C', capacity: 8 },
   ];
 
-  it('모든 회의실 옵션을 올바르게 렌더링해야 함', async () => {
+  it('모든 공간 옵션을 올바르게 렌더링해야 함', async () => {
     const user = userEvent.setup();
 
     render(
@@ -24,12 +24,12 @@ describe('RoomSelector', () => {
     const select = screen.getByRole('combobox');
     await user.click(select);
 
-    expect(screen.getByText('회의실 A (최대 10인)')).toBeInTheDocument();
-    expect(screen.getByText('회의실 B (최대 20인)')).toBeInTheDocument();
-    expect(screen.getByText('회의실 C (최대 8인)')).toBeInTheDocument();
+    expect(screen.getByText('공간 A (최대 10인)')).toBeInTheDocument();
+    expect(screen.getByText('공간 B (최대 20인)')).toBeInTheDocument();
+    expect(screen.getByText('공간 C (최대 8인)')).toBeInTheDocument();
   });
 
-  it('회의실 선택 시 onChange를 올바른 roomId로 호출해야 함', async () => {
+  it('공간 선택 시 onChange를 올바른 roomId로 호출해야 함', async () => {
     const user = userEvent.setup();
     const handleChange = vi.fn();
 
@@ -44,7 +44,7 @@ describe('RoomSelector', () => {
     const select = screen.getByRole('combobox');
     await user.click(select);
 
-    const option = screen.getByText('회의실 A (최대 10인)');
+    const option = screen.getByText('공간 A (최대 10인)');
     await user.click(option);
 
     expect(handleChange).toHaveBeenCalledWith('room-1');
@@ -73,10 +73,10 @@ describe('RoomSelector', () => {
       />,
     );
 
-    expect(screen.getByText('확정할 회의실을 선택하세요')).toBeInTheDocument();
+    expect(screen.getByText('확정할 공간을 선택하세요')).toBeInTheDocument();
   });
 
-  it('선택된 회의실이 올바르게 표시되어야 함', () => {
+  it('선택된 공간이 올바르게 표시되어야 함', () => {
     render(
       <RoomSelector
         rooms={mockRooms}
@@ -86,6 +86,6 @@ describe('RoomSelector', () => {
     );
 
     const select = screen.getByRole('combobox');
-    expect(select).toHaveTextContent('회의실 B');
+    expect(select).toHaveTextContent('공간 B');
   });
 });

--- a/apps/web/src/components/room-selector.tsx
+++ b/apps/web/src/components/room-selector.tsx
@@ -22,7 +22,7 @@ export default function RoomSelector({
   return (
     <Box sx={{ mb: 2 }}>
       <Typography variant="subtitle2" gutterBottom fontWeight={500}>
-        회의실 선택
+        공간 선택
       </Typography>
       <TextField
         select
@@ -30,7 +30,7 @@ export default function RoomSelector({
         value={selectedRoomId || ''}
         onChange={(e) => onChange(e.target.value)}
         disabled={disabled}
-        helperText="확정할 회의실을 선택하세요"
+        helperText="확정할 공간을 선택하세요"
       >
         <MenuItem value="">
           <em>선택 안함</em>

--- a/apps/web/src/components/section-header.test.tsx
+++ b/apps/web/src/components/section-header.test.tsx
@@ -70,14 +70,14 @@ describe('SectionHeader', () => {
     const action = <button type="button">새로 만들기</button>;
     render(
       <SectionHeader
-        title="회의 목록"
-        subtitle="총 5개의 회의"
+        title="만남 목록"
+        subtitle="총 5개의 만남"
         action={action}
       />,
     );
 
-    expect(screen.getByRole('heading', { name: '회의 목록' })).toBeInTheDocument();
-    expect(screen.getByText('총 5개의 회의')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '만남 목록' })).toBeInTheDocument();
+    expect(screen.getByText('총 5개의 만남')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '새로 만들기' })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/CreatePage.test.tsx
+++ b/apps/web/src/pages/CreatePage.test.tsx
@@ -34,7 +34,7 @@ describe('CreatePage', () => {
 
   it('제목이 올바르게 표시되어야 한다', () => {
     renderWithProviders(<CreatePage />);
-    expect(screen.getByText('새 회의 일정 만들기')).toBeInTheDocument();
+    expect(screen.getByText('새 만남 일정 만들기')).toBeInTheDocument();
   });
 
   it('제목 입력 필드가 있어야 한다', () => {
@@ -81,7 +81,7 @@ describe('CreatePage', () => {
   it('제목을 입력할 수 있어야 한다', () => {
     renderWithProviders(<CreatePage />);
     const input = screen.getByLabelText('제목 *');
-    fireEvent.change(input, { target: { value: '팀 회의' } });
-    expect(input).toHaveValue('팀 회의');
+    fireEvent.change(input, { target: { value: '팀 정기만남' } });
+    expect(input).toHaveValue('팀 정기만남');
   });
 });

--- a/apps/web/src/pages/CreatePage.tsx
+++ b/apps/web/src/pages/CreatePage.tsx
@@ -89,6 +89,11 @@ export default function CreatePage() {
       return;
     }
 
+    if (meetingType === 'company_dinner' && !mealTime) {
+      toast.error('회식인 경우 식사 시간을 선택해주세요.');
+      return;
+    }
+
     const responseDeadlineAt = getResponseDeadlineISO();
 
     if (responseDeadlineAt) {

--- a/apps/web/src/pages/CreatePage.tsx
+++ b/apps/web/src/pages/CreatePage.tsx
@@ -32,6 +32,8 @@ export default function CreatePage() {
   const [durationMinutes, setDurationMinutes] = useState(60);
   const [responseDeadlineType, setResponseDeadlineType] = useState<ResponseDeadlineType>('none');
   const [customDeadline, setCustomDeadline] = useState('');
+  const [meetingType, setMeetingType] = useState<'general' | 'company_dinner'>('general');
+  const [mealTime, setMealTime] = useState<'lunch' | 'dinner' | ''>('');
 
   const getToday18ISO = () => {
     const now = new Date();
@@ -110,6 +112,8 @@ export default function CreatePage() {
       durationMinutes,
       location: '',
       responseDeadlineAt,
+      meetingType,
+      mealTime,
     };
 
       navigate('/requests/new/slots', {
@@ -125,7 +129,7 @@ export default function CreatePage() {
             <ArrowBackIcon />
           </IconButton>
           <Typography variant="h6" component="div" sx={{ fontWeight: 600 }}>
-            새 회의 일정 만들기
+            새 만남 일정 만들기
           </Typography>
         </Toolbar>
       </AppBar>
@@ -136,7 +140,7 @@ export default function CreatePage() {
           label="제목 *"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          placeholder="예: 팀 주간회의"
+          placeholder="예: 팀 주간 정기만남"
           sx={{ mb: 3 }}
         />
 
@@ -145,7 +149,7 @@ export default function CreatePage() {
           label="설명"
           value={description}
           onChange={(e) => setDescription(e.target.value)}
-          placeholder="회의에 대한 간단한 설명"
+          placeholder="만남에 대한 간단한 설명"
           multiline
           rows={3}
           sx={{ mb: 3 }}
@@ -189,6 +193,33 @@ export default function CreatePage() {
           >
             참석자 추가
           </Button>
+        </Box>
+
+        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 2, mb: 3 }}>
+          <TextField
+            select
+            label="만남 종류"
+            value={meetingType}
+            onChange={(e) => {
+              setMeetingType(e.target.value as 'general' | 'company_dinner');
+              setMealTime('');
+            }}
+          >
+            <MenuItem value="general">일반</MenuItem>
+            <MenuItem value="company_dinner">회식</MenuItem>
+          </TextField>
+          {meetingType === 'company_dinner' && (
+            <TextField
+              select
+              label="식사 시간"
+              value={mealTime}
+              onChange={(e) => setMealTime(e.target.value as 'lunch' | 'dinner' | '')}
+              helperText="회식인 경우 점심/저녁 시간을 선택해주세요"
+            >
+              <MenuItem value="lunch">점심 12~13시</MenuItem>
+              <MenuItem value="dinner">저녁 18~20시</MenuItem>
+            </TextField>
+          )}
         </Box>
 
         <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr 1fr' }, gap: 2, mb: 3 }}>
@@ -265,7 +296,7 @@ export default function CreatePage() {
           </Typography>
           <Typography variant="body2" component="div">
             <ul style={{ margin: 0, paddingLeft: '1.5rem' }}>
-              <li>회의 시간은 30분 단위로 생성됩니다.</li>
+              <li>만남 시간은 30분 단위로 생성됩니다.</li>
               <li>시간/요일 제한은 추후 옵션으로 제공할 수 있습니다.</li>
               <li>생성 후 대시보드에서 참석자들에게 응답 링크를 공유하세요.</li>
             </ul>

--- a/apps/web/src/pages/DashboardPage.test.tsx
+++ b/apps/web/src/pages/DashboardPage.test.tsx
@@ -63,7 +63,7 @@ describe('DashboardPage', () => {
   it('데이터 로드 후 제목이 표시되어야 한다', async () => {
     const mockData = {
       requestId: 'req-1',
-      title: '팀 회의',
+      title: '팀 만남',
       status: 'OPEN',
       participants: [{ userId: 'user-1', name: '홍길동', responded: true }],
       commonAvailableSlots: [
@@ -84,7 +84,7 @@ describe('DashboardPage', () => {
     renderWithProviders(<DashboardPage />);
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: '팀 회의' })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: '팀 만남' })).toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -14,9 +14,9 @@ import ShareIcon from '@mui/icons-material/Share';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 
 const mockRooms = [
-  { id: '1', name: '1층 회의실 A', capacity: 10 },
-  { id: '2', name: '1층 회의실 B', capacity: 8 },
-  { id: '3', name: '2층 대회의실', capacity: 20 },
+  { id: '1', name: '1층 공간 A', capacity: 10 },
+  { id: '2', name: '1층 공간 B', capacity: 8 },
+  { id: '3', name: '2층 대공간', capacity: 20 },
 ];
 
 export default function DashboardPage() {
@@ -51,7 +51,7 @@ export default function DashboardPage() {
   const confirmMutation = useMutation({
     mutationFn: (dto: ConfirmMeetingDto) => confirmMeeting(dto),
     onSuccess: () => {
-      toast.success('회의가 확정되었습니다!');
+      toast.success('만남이 확정되었습니다!');
       queryClient.invalidateQueries({ queryKey: ['dashboard', id] });
       navigate('/');
     },
@@ -100,8 +100,8 @@ export default function DashboardPage() {
     if (navigator.share) {
       try {
         await navigator.share({
-          title: data?.title || '회의 일정',
-          text: `${data?.title || '회의 일정'}에 참석해주세요.`,
+          title: data?.title || '만남 일정',
+          text: `${data?.title || '만남 일정'}에 참석해주세요.`,
           url: responseLink,
         });
       } catch (_error) {
@@ -231,8 +231,8 @@ export default function DashboardPage() {
           {/* Room Selection */}
           <Grid item xs={12}>
             <SectionHeader
-              title="회의실 선택"
-              subtitle="확정할 시간을 선택한 후 회의실을 선택하세요"
+          title="공간 선택"
+          subtitle="확정할 시간을 선택한 후 공간을 선택하세요"
             />
             <RoomSelector
               rooms={mockRooms}
@@ -257,7 +257,7 @@ export default function DashboardPage() {
                 disabled={!selectedTimeSlot || !selectedRoomId || confirmMutation.isPending}
                 startIcon={<ShareIcon />}
               >
-                {confirmMutation.isPending ? '확정 중...' : '회의 확정'}
+                {confirmMutation.isPending ? '확정 중...' : '만남 확정'}
               </Button>
             </Box>
           </Grid>

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -104,7 +104,7 @@ export default function DashboardPage() {
           text: `${data?.title || '만남 일정'}에 참석해주세요.`,
           url: responseLink,
         });
-      } catch (_error) {
+      } catch {
         handleCopyLink();
       }
     } else {
@@ -131,6 +131,11 @@ export default function DashboardPage() {
     : 0;
   const respondedCount = data.participants.filter((p: { responded: boolean }) => p.responded).length;
   const totalCount = data.participants.length;
+
+  const meetingTypeLabel = data.meetingType === 'COMPANY_DINNER' ? '회식' : '일반';
+  const mealTimeLabel = data.mealTime === 'LUNCH' ? '점심 12~13시'
+    : data.mealTime === 'DINNER' ? '저녁 18~20시'
+    : undefined;
 
   const participants = data.participants.map((p: { userId: string; name: string; responded: boolean }) => ({
     id: p.userId,
@@ -198,6 +203,18 @@ export default function DashboardPage() {
                   color={responseRate >= 80 ? 'success' : responseRate >= 50 ? 'warning' : 'error'}
                   variant="outlined"
                 />
+                <Chip
+                  label={`유형: ${meetingTypeLabel}`}
+                  color={data.meetingType === 'COMPANY_DINNER' ? 'primary' : 'default'}
+                  variant="outlined"
+                />
+                {mealTimeLabel && (
+                  <Chip
+                    label={`식사 시간: ${mealTimeLabel}`}
+                    color="primary"
+                    variant="outlined"
+                  />
+                )}
               </Box>
             </Paper>
           </Grid>

--- a/apps/web/src/pages/HomePage.test.tsx
+++ b/apps/web/src/pages/HomePage.test.tsx
@@ -96,11 +96,11 @@ describe('HomePage', () => {
     renderWithProviders(<HomePage />);
 
     await waitFor(() => {
-      expect(screen.getByText('WhatTime')).toBeInTheDocument();
+      expect(screen.getByText('우리지금만나')).toBeInTheDocument();
     });
   });
 
-  it('진행 중인 회의가 없으면 메시지가 표시되어야 한다', async () => {
+  it('진행 중인 만남이 없으면 메시지가 표시되어야 한다', async () => {
     const health: HealthPayload = { status: 'ok', timestamp: '2026-01-13T00:00:00Z', uptime: 100 };
     const meetings: MeetingsPayload = { meetings: [] };
 
@@ -118,11 +118,11 @@ describe('HomePage', () => {
     renderWithProviders(<HomePage />);
 
     await waitFor(() => {
-      expect(screen.getByText('진행 중인 회의가 없습니다.')).toBeInTheDocument();
+      expect(screen.getByText('진행 중인 만남이 없습니다.')).toBeInTheDocument();
     });
   });
 
-  it('완료된 회의가 없으면 메시지가 표시되어야 한다', async () => {
+  it('완료된 만남이 없으면 메시지가 표시되어야 한다', async () => {
     const health: HealthPayload = { status: 'ok', timestamp: '2026-01-13T00:00:00Z', uptime: 100 };
     const meetings: MeetingsPayload = { meetings: [] };
 
@@ -140,7 +140,7 @@ describe('HomePage', () => {
     renderWithProviders(<HomePage />);
 
     await waitFor(() => {
-      expect(screen.getByText('완료된 회의가 없습니다.')).toBeInTheDocument();
+      expect(screen.getByText('완료된 만남이 없습니다.')).toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -39,7 +39,7 @@ export default function HomePage() {
     return (
       <Box sx={{ p: 4, textAlign: 'center' }}>
         <Typography variant="h4" gutterBottom>
-          WhatTime - 회의 예약 시스템
+          우리지금만나 - 만남 예약 시스템
         </Typography>
         <Typography color="error">서버 연결 실패</Typography>
       </Box>
@@ -50,7 +50,7 @@ export default function HomePage() {
     <Container maxWidth="lg" sx={{ py: 4 }}>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 4 }}>
         <Typography variant="h4" fontWeight={600}>
-          WhatTime
+          우리지금만나
         </Typography>
       </Box>
 
@@ -65,18 +65,18 @@ export default function HomePage() {
             onClick={() => navigate('/requests/new')}
             startIcon={<span>+</span>}
           >
-            새 회의 일정 만들기
+            새 만남 일정 만들기
           </Button>
         </Box>
       </Box>
       )}
 
       <Typography variant="h6" gutterBottom fontWeight={600}>
-        진행 중인 회의
+        진행 중인 만남
       </Typography>
       {activeMeetings.length === 0 ? (
         <Typography color="text.secondary" sx={{ mb: 4 }}>
-          진행 중인 회의가 없습니다.
+          진행 중인 만남이 없습니다.
         </Typography>
       ) : (
         <Grid container spacing={2} sx={{ mb: 4 }}>
@@ -96,11 +96,11 @@ export default function HomePage() {
       )}
 
       <Typography variant="h6" gutterBottom fontWeight={600}>
-        완료된 회의
+        완료된 만남
       </Typography>
       {completedMeetings.length === 0 ? (
         <Typography color="text.secondary">
-          완료된 회의가 없습니다.
+          완료된 만남이 없습니다.
         </Typography>
       ) : (
         <Grid container spacing={2}>

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -88,6 +88,8 @@ export default function HomePage() {
                 responseRate={meeting.responseRate}
                 totalParticipants={5}
                 respondedParticipants={Math.round(5 * meeting.responseRate / 100)}
+                meetingType={meeting.meetingType}
+                mealTime={meeting.mealTime}
                 onClick={() => navigate(`/requests/${meeting.id}/dashboard`)}
               />
             </Grid>
@@ -112,6 +114,8 @@ export default function HomePage() {
                 responseRate={100}
                 totalParticipants={5}
                 respondedParticipants={5}
+                meetingType={meeting.meetingType}
+                mealTime={meeting.mealTime}
                 onClick={() => navigate(`/requests/${meeting.id}/dashboard`)}
               />
             </Grid>

--- a/apps/web/src/pages/OrganizerSlotSelectionPage.tsx
+++ b/apps/web/src/pages/OrganizerSlotSelectionPage.tsx
@@ -53,7 +53,7 @@ export default function OrganizerSlotSelectionPage() {
 
   useEffect(() => {
     if (!meetingData || !meetingData.title || !meetingData.startDate || !meetingData.endDate) {
-      toast.error('회의 정보가 없습니다. 다시 생성해주세요.');
+      toast.error('만남 정보가 없습니다. 다시 생성해주세요.');
       navigate('/new');
       return;
     }
@@ -128,10 +128,10 @@ export default function OrganizerSlotSelectionPage() {
       }
 
       const data = await response.json();
-      toast.success('회의 요청이 생성되었습니다!');
+      toast.success('만남 요청이 생성되었습니다!');
       navigate(`/requests/${data.id}/dashboard`);
     } catch {
-      toast.error('회의 요청 생성에 실패했습니다.');
+      toast.error('만남 요청 생성에 실패했습니다.');
     } finally {
       setIsSubmitting(false);
     }
@@ -201,7 +201,7 @@ export default function OrganizerSlotSelectionPage() {
           가능한 시간 선택
         </Typography>
         <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
-          회의를 진행할 수 있는 시간을 모두 선택해주세요.
+          만남을 진행할 수 있는 시간을 모두 선택해주세요.
         </Typography>
 
         <Grid container spacing={2.5} sx={{ mb: 8 }}>
@@ -220,7 +220,7 @@ export default function OrganizerSlotSelectionPage() {
               }}
             >
               <Typography variant="subtitle1" fontWeight={600} gutterBottom sx={{ mb: 2 }}>
-                회의 정보
+                만남 정보
               </Typography>
               <Divider sx={{ mb: 2, borderColor: 'divider' }} />
 
@@ -532,7 +532,7 @@ export default function OrganizerSlotSelectionPage() {
               fontWeight: 600,
             }}
           >
-            {isSubmitting ? '생성 중...' : `회의 생성 (${Object.keys(selectedSlots).length}개 선택)`}
+            {isSubmitting ? '생성 중...' : `만남 생성 (${Object.keys(selectedSlots).length}개 선택)`}
           </Button>
         </Container>
       </Box>

--- a/apps/web/src/pages/OrganizerSlotSelectionPage.tsx
+++ b/apps/web/src/pages/OrganizerSlotSelectionPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { generateTimeSlots, formatDateDisplay } from '../utils/timeSlot';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useToast } from '@/hooks/useToast';
@@ -23,7 +23,8 @@ import PeopleIcon from '@mui/icons-material/People';
 import DescriptionIcon from '@mui/icons-material/Description';
 
 // Temporary blocking logic - can be enhanced with external adapters later
-const isBlockedSlot = (_date: string, time: string) => {
+const isBlockedSlot = (_date: string, time: string, meetingType?: 'general' | 'company_dinner') => {
+  if (meetingType === 'company_dinner') return false;
   if (time.startsWith('12:')) return true;
   return false;
 };
@@ -39,6 +40,8 @@ interface MeetingFormData {
   durationMinutes: number;
   location?: string;
   responseDeadlineAt?: string | null;
+  meetingType?: 'general' | 'company_dinner';
+  mealTime?: 'lunch' | 'dinner' | '';
 }
 
 export default function OrganizerSlotSelectionPage() {
@@ -51,6 +54,59 @@ export default function OrganizerSlotSelectionPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
 
+  const meetingType = meetingData?.meetingType ?? 'general';
+  const mealTime = meetingData?.mealTime ?? '';
+
+  const toMinutes = (time: string) => {
+    const [hours, minutes] = time.split(':').map(Number);
+    return hours * 60 + minutes;
+  };
+
+  const getMealTimeRange = (value: typeof mealTime) => {
+    if (value === 'lunch') {
+      return { start: 12 * 60, end: 13 * 60 };
+    }
+
+    if (value === 'dinner') {
+      return { start: 18 * 60, end: 20 * 60 };
+    }
+
+    return null;
+  };
+
+  const filterSlotsForMealTime = (slots: string[]) => {
+    if (meetingType !== 'company_dinner' || !mealTime) {
+      return slots;
+    }
+
+    const range = getMealTimeRange(mealTime);
+    if (!range) {
+      return [];
+    }
+
+    return slots.filter((slot) => {
+      const [, time] = slot.split('|');
+      if (!time) return false;
+      const minutes = toMinutes(time);
+      return minutes >= range.start && minutes < range.end;
+    });
+  };
+
+  const buildTimeSlotData = useCallback(() => {
+    const baseSlots = generateTimeSlots(meetingData?.startDate || '', meetingData?.endDate || '');
+
+    if (meetingType !== 'company_dinner') {
+      return baseSlots;
+    }
+
+    return baseSlots
+      .map((dateSlot) => ({
+        ...dateSlot,
+        slots: filterSlotsForMealTime(dateSlot.slots),
+      }))
+      .filter((dateSlot) => dateSlot.slots.length > 0);
+  }, [meetingData?.startDate, meetingData?.endDate, meetingType, mealTime, filterSlotsForMealTime]);
+
   useEffect(() => {
     if (!meetingData || !meetingData.title || !meetingData.startDate || !meetingData.endDate) {
       toast.error('만남 정보가 없습니다. 다시 생성해주세요.');
@@ -58,16 +114,19 @@ export default function OrganizerSlotSelectionPage() {
       return;
     }
 
-    const timeSlotData = generateTimeSlots(meetingData.startDate || '', meetingData.endDate || '');
+    if (meetingType === 'company_dinner' && !mealTime) {
+      toast.error('회식인 경우 식사 시간을 선택해주세요.');
+      navigate('/requests/new');
+      return;
+    }
+
+    const timeSlotData = buildTimeSlotData();
     if (timeSlotData.length > 0 && !selectedDate) {
       setSelectedDate(timeSlotData[0].date);
     }
-  }, [meetingData, navigate, selectedDate]);
+  }, [meetingData, meetingType, mealTime, navigate, selectedDate, buildTimeSlotData, toast]);
 
-  const startDateString = meetingData?.startDate;
-  const endDateString = meetingData?.endDate;
-
-  const timeSlotData = generateTimeSlots(startDateString || '', endDateString || '');
+  const timeSlotData = buildTimeSlotData();
 
   const toggleSlot = (slotIso: string) => {
     setSelectedSlots((prev) => {
@@ -91,7 +150,7 @@ export default function OrganizerSlotSelectionPage() {
       dateSlots.slots.forEach((slot) => {
         const [slotIso, time] = slot.split('|');
         if (!slotIso || !time) return;
-        if (isBlockedSlot(date, time)) return;
+        if (isBlockedSlot(date, time, meetingType)) return;
         if (value) {
           next[slotIso] = true;
         } else {
@@ -114,11 +173,16 @@ export default function OrganizerSlotSelectionPage() {
 
     setIsSubmitting(true);
     try {
+      const mappedMeetingType = meetingType === 'company_dinner' ? 'COMPANY_DINNER' : 'GENERAL';
+      const mappedMealTime = mealTime === 'lunch' ? 'LUNCH' : mealTime === 'dinner' ? 'DINNER' : null;
+
       const response = await fetch('/api/meetings', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           ...meetingData,
+          meetingType: mappedMeetingType,
+          mealTime: mappedMealTime,
           organizerAvailableSlots: Object.keys(selectedSlots),
         }),
       });
@@ -450,7 +514,7 @@ export default function OrganizerSlotSelectionPage() {
                       if (!slotIso || !time) return null;
 
                       const isSelected = selectedSlots[slotIso];
-                      const isBlocked = isBlockedSlot(selectedDateSlots.date, time);
+                      const isBlocked = isBlockedSlot(selectedDateSlots.date, time, meetingType);
 
                       return (
                         <Button

--- a/apps/web/src/pages/OrganizerSlotSelectionPage.tsx
+++ b/apps/web/src/pages/OrganizerSlotSelectionPage.tsx
@@ -62,7 +62,7 @@ export default function OrganizerSlotSelectionPage() {
     return hours * 60 + minutes;
   };
 
-  const getMealTimeRange = (value: typeof mealTime) => {
+  const getMealTimeRange = useCallback((value: typeof mealTime) => {
     if (value === 'lunch') {
       return { start: 12 * 60, end: 13 * 60 };
     }
@@ -72,9 +72,9 @@ export default function OrganizerSlotSelectionPage() {
     }
 
     return null;
-  };
+  }, []);
 
-  const filterSlotsForMealTime = (slots: string[]) => {
+  const filterSlotsForMealTime = useCallback((slots: string[]) => {
     if (meetingType !== 'company_dinner' || !mealTime) {
       return slots;
     }
@@ -90,7 +90,7 @@ export default function OrganizerSlotSelectionPage() {
       const minutes = toMinutes(time);
       return minutes >= range.start && minutes < range.end;
     });
-  };
+  }, [meetingType, mealTime, getMealTimeRange]);
 
   const buildTimeSlotData = useCallback(() => {
     const baseSlots = generateTimeSlots(meetingData?.startDate || '', meetingData?.endDate || '');
@@ -105,7 +105,7 @@ export default function OrganizerSlotSelectionPage() {
         slots: filterSlotsForMealTime(dateSlot.slots),
       }))
       .filter((dateSlot) => dateSlot.slots.length > 0);
-  }, [meetingData?.startDate, meetingData?.endDate, meetingType, mealTime, filterSlotsForMealTime]);
+  }, [meetingData?.startDate, meetingData?.endDate, meetingType, filterSlotsForMealTime]);
 
   useEffect(() => {
     if (!meetingData || !meetingData.title || !meetingData.startDate || !meetingData.endDate) {

--- a/apps/web/src/pages/ResponsePage.test.tsx
+++ b/apps/web/src/pages/ResponsePage.test.tsx
@@ -44,7 +44,7 @@ describe('ResponsePage', () => {
 
     const mockDashboard = {
       requestId: 'req-1',
-      title: '팀 회의',
+      title: '팀 만남',
       status: 'OPEN',
       participants: [{ userId: 'user-1', name: '홍길동', responded: false }],
       startDate: '2026-01-20',
@@ -62,7 +62,7 @@ describe('ResponsePage', () => {
 
   it('제목이 올바르게 표시되어야 한다', () => {
     renderWithProviders(<ResponsePage />);
-    expect(screen.getAllByText('회의 일정 응답')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('만남 일정 응답')[0]).toBeInTheDocument();
   });
 
   it('이름 입력 필드가 있어야 한다', () => {

--- a/apps/web/src/pages/ResponsePage.tsx
+++ b/apps/web/src/pages/ResponsePage.tsx
@@ -31,7 +31,7 @@ export default function ResponsePage() {
     if (!value) return null;
     try {
       return JSON.parse(value) as { message?: string } | null;
-    } catch (error) {
+    } catch {
       return null;
     }
   };
@@ -87,11 +87,13 @@ export default function ResponsePage() {
   const [selectedUserId, setSelectedUserId] = useState<string>('');
 
   useEffect(() => {
-    if (!selectedUserId && participants.length > 0) {
-      setSelectedUserId(participants[0].userId);
-      setName(participants[0].name);
-    }
-  }, [participants, selectedUserId]);
+    if (participants.length === 0) return;
+
+    /* eslint-disable react-hooks/set-state-in-effect */
+    setSelectedUserId((prev) => prev || participants[0].userId);
+    setName((prev) => prev || participants[0].name);
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, [participants]);
 
   const startDateString = dashboardData?.startDate;
   const endDateString = dashboardData?.endDate;

--- a/apps/web/src/pages/ResponsePage.tsx
+++ b/apps/web/src/pages/ResponsePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useToast } from '@/hooks/useToast';
@@ -83,17 +83,13 @@ export default function ResponsePage() {
     },
   });
 
-  const participants = dashboardData?.participants ?? [];
-  const [selectedUserId, setSelectedUserId] = useState<string>('');
+const participants = useMemo(() => dashboardData?.participants ?? [], [dashboardData?.participants]);
+const [selectedUserId, setSelectedUserId] = useState<string>('');
 
-  useEffect(() => {
-    if (participants.length === 0) return;
+const defaultParticipant = participants[0];
+const effectiveSelectedUserId = selectedUserId || defaultParticipant?.userId || '';
+const effectiveName = name || defaultParticipant?.name || '';
 
-    /* eslint-disable react-hooks/set-state-in-effect */
-    setSelectedUserId((prev) => prev || participants[0].userId);
-    setName((prev) => prev || participants[0].name);
-    /* eslint-enable react-hooks/set-state-in-effect */
-  }, [participants]);
 
   const startDateString = dashboardData?.startDate;
   const endDateString = dashboardData?.endDate;
@@ -168,16 +164,16 @@ export default function ResponsePage() {
 
   const submitMutation = useMutation({
     mutationFn: async () => {
-      if (!selectedUserId) {
+      if (!effectiveSelectedUserId) {
         throw new Error('참여자를 선택해주세요.');
       }
 
-      const selectedParticipant = participants.find((p) => p.userId === selectedUserId);
+      const selectedParticipant = participants.find((p) => p.userId === effectiveSelectedUserId);
       if (!selectedParticipant) {
         throw new Error('참여자를 다시 선택해주세요.');
       }
 
-      const participantName = name || selectedParticipant.name;
+      const participantName = effectiveName || selectedParticipant.name;
       if (!participantName) {
         throw new Error('이름을 입력해주세요.');
       }
@@ -186,7 +182,7 @@ export default function ResponsePage() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          userId: selectedUserId,
+          userId: effectiveSelectedUserId,
           name: participantName,
           availableSlots: Object.entries(slotSelections)
             .filter(([, status]) => status === 'available')
@@ -305,7 +301,7 @@ export default function ResponsePage() {
               <InputLabel id="participant-select-label">참여자</InputLabel>
               <Select
                 labelId="participant-select-label"
-                value={selectedUserId}
+                value={effectiveSelectedUserId}
                 label="참여자"
                 onChange={(e) => {
                   const userId = String(e.target.value);
@@ -332,7 +328,7 @@ export default function ResponsePage() {
           </Typography>
           <input
             type="text"
-            value={name}
+            value={effectiveName}
             onChange={(e) => setName(e.target.value)}
             placeholder="홍길동"
             disabled={isSubmitting}

--- a/apps/web/src/pages/ResponsePage.tsx
+++ b/apps/web/src/pages/ResponsePage.tsx
@@ -270,15 +270,15 @@ export default function ResponsePage() {
           <IconButton onClick={() => navigate('/')} color="inherit">
             <ArrowBackIcon />
           </IconButton>
-          <Typography variant="h6" component="div" sx={{ fontWeight: 600 }}>
-            회의 일정 응답
-          </Typography>
+            <Typography variant="h6" component="div" sx={{ fontWeight: 600 }}>
+              만남 일정 응답
+            </Typography>
         </Toolbar>
       </AppBar>
 
       <Box sx={{ padding: '1rem', paddingBottom: '8rem', flex: 1 }}>
         <Typography variant="h4" gutterBottom fontWeight={600}>
-          회의 일정 응답
+          만남 일정 응답
         </Typography>
         <Typography variant="body2" color="text.secondary" sx={{ marginBottom: '1.5rem' }}>
           가능한 시간을 선택하세요 (불가능한 시간은 자동으로 표시됩니다)

--- a/packages/shared/src/dto.ts
+++ b/packages/shared/src/dto.ts
@@ -11,6 +11,16 @@ export enum TimeSlotStatus {
   BLOCKED = 'BLOCKED',
 }
 
+export enum MeetingType {
+  GENERAL = 'GENERAL',
+  COMPANY_DINNER = 'COMPANY_DINNER',
+}
+
+export enum MealTime {
+  LUNCH = 'LUNCH',
+  DINNER = 'DINNER',
+}
+
 export interface CreateMeetingRequestDto {
   title: string;
   description?: string;
@@ -23,6 +33,8 @@ export interface CreateMeetingRequestDto {
   location?: string;
   organizerAvailableSlots?: string[];
   responseDeadlineAt?: string | null;
+  meetingType?: MeetingType;
+  mealTime?: MealTime | null;
 }
 
 export interface CreateMeetingResponseDto {
@@ -35,6 +47,8 @@ export interface CreateMeetingResponseDto {
   durationMinutes: number;
   createdAt: string;
   responseDeadlineAt?: string | null;
+  meetingType: MeetingType;
+  mealTime?: MealTime | null;
 }
 
 export interface CreateParticipantResponseDto {
@@ -50,6 +64,8 @@ export interface DashboardDto {
   title: string;
   description?: string;
   status: MeetingRequestStatus;
+  meetingType: MeetingType;
+  mealTime?: MealTime | null;
   participants: Array<{
     userId: string;
     name: string;


### PR DESCRIPTION
## 요약
- 회식(Company Dinner) 타입과 식사시간(lunch/dinner)을 Prisma/DTO/API까지 영속화
- 생성 API에서 회식일 때 mealTime 필수 검증, 일반 모임에는 mealTime 미허용
- 웹 생성 플로우에서 타입/식사시간 전송 및 대시보드·목록 카드에 표시

## 동작/규칙
- 회식 선택 시 식사시간 필수
- 회식일 때 점심(12~13) 또는 저녁(18~20) 슬롯만 노출
- 대시보드/목록에서 회식 여부 및 식사시간 구분 가능

## 변경 범위
- Prisma: MeetingType/MealTime enum, MeetingRequest 필드 추가
- Shared DTO: meetingType/mealTime 필드 추가
- API: create/dashboard/list 응답에 필드 포함
- Web: create payload 포함 + 카드/대시보드 표시

## 테스트
- pnpm run lint (coverage/hook 경고 존재)
- pnpm --filter shared build
- pnpm --filter api build
- pnpm --filter web build

Closes #15
